### PR TITLE
Fixed spx2: updateProject failed when  editorCanvas is invisible

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2280,8 +2280,8 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	}
 
 	reimport_files.sort();
-
-	bool use_multiple_threads = GLOBAL_GET("editor/import/use_multiple_threads");
+	// gdspx disable mutil threads import
+	bool use_multiple_threads = GLOBAL_GET("editor/import/use_multiple_threads") && use_threads;
 
 	int from = 0;
 	for (int i = 0; i < reimport_files.size(); i++) {
@@ -2609,7 +2609,7 @@ EditorFileSystem::EditorFileSystem() {
 #ifdef WEB_ENABLED
 	// disable mutilthread import in web platform
 	use_threads = false;
-	print_line("EditorFileSystem disable mutil thread ");
+	print_line("EditorFileSystem disable mutil thread ",use_threads);
 #endif
 	ResourceLoader::import = _resource_import;
 	reimport_on_missing_imported_files = GLOBAL_GET("editor/import/reimport_missing_imported_files");

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -378,7 +378,7 @@ const GodotEditorEventHandler = {
 		handler_update_project: async function (ev) {
 			let infos = ev.detail
 			// 1. handle delete files
-			GodotEditorEventHandler.deleteFilesCB(infos.deletedInfos);
+			GodotEditorEventHandler.deleteFilesCB(infos.deleteInfos);
 			// 2. add or update files
 			GodotEditorEventHandler.add_or_update_files(infos.dirtyInfos)
 			// 3. callback 


### PR DESCRIPTION
fix : https://github.com/goplus/spx/issues/402


Temp solution : use print_line to force fs to sync when canvas is not visible
Disable mutil_thread importer on web platform
Fix typo error: update project deleteInfos