### PR TITLE
Add a js callback: 'select_dir' to fix the bug updateProject

### DIFF
--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -126,6 +126,8 @@ private:
 	static void _delete_files_js_callback(const Vector<String> &p_files);
 	WASM_EXPORT static void update_files_js_callback(const char **p_filev, int p_filec);
 	static void _update_files_js_callback(const Vector<String> &p_files);
+	WASM_EXPORT static void select_dir_callback(const char *p_text);
+	static void _select_dir_callback(const String &p_text);
 
 	void process_joypads();
 

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -76,6 +76,7 @@ extern void godot_js_input_paste_cb(void (*p_callback)(const char *p_text));
 extern void godot_js_input_drop_files_cb(void (*p_callback)(const char **p_filev, int p_filec));
 extern void godot_js_delete_files_cb(void (*p_callback)(const char **p_filev, int p_filec));
 extern void godot_js_update_files_cb(void (*p_callback)(const char **p_filev, int p_filec));
+extern void godot_js_select_dir_cb(void (*p_callback)(const char *p_path));
 
 // TTS
 extern int godot_js_tts_is_speaking();

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -339,6 +339,7 @@ const GodotEditorEventHandler = {
 	$GodotEditorEventHandler: {
 		addOrUpdateFilesCB: {},
 		deleteFilesCB: {},
+		selectDirCB: {},
 
 		add_or_update_files: function (infos) {
 			const drops = [];
@@ -390,10 +391,11 @@ const GodotEditorEventHandler = {
 
 		handler_update_project: async function (ev) {
 			let infos = ev.detail
-			// 1. handle delete files
-			GodotEditorEventHandler.deleteFilesCB(infos.deleteInfos);
-			// 2. add or update files
+			GodotEditorEventHandler.selectDirCB("res://")
+			// 1. add or update files
 			GodotEditorEventHandler.add_or_update_files(infos.dirtyInfos)
+			// 2. handle delete files
+			GodotEditorEventHandler.deleteFilesCB(infos.deleteInfos);
 			// 3. callback 
 			let start_frame = GodotOS.frame_num
 			await GodotOS.get_sync_done_promise()
@@ -422,6 +424,19 @@ const GodotEditorEventHandler = {
 		const canvas = GodotConfig.canvas;
 		GodotEditorEventHandler.deleteFilesCB = delete_files;
 	},
+
+	godot_js_select_dir_cb__proxy: 'sync',
+	godot_js_select_dir_cb__sig: 'vi',
+	godot_js_select_dir_cb: function (p_callback) {
+		const func = GodotRuntime.get_func(p_callback);
+		const select_dir = function (path) {
+			const ptr = GodotRuntime.allocString(path);
+			func(ptr);
+			GodotRuntime.free(ptr);
+		};
+		GodotEditorEventHandler.selectDirCB = select_dir
+	},
+
 
 	godot_js_update_files_cb__proxy: 'sync',
 	godot_js_update_files_cb__sig: 'vi',


### PR DESCRIPTION
fix: https://github.com/goplus/spx/issues/402
Add a js callback: 'select_dir' to fix the bug where 'updateProject updates to the incorrect directory.

