### PR TITLE
Fix event “wait_fs_sync_done” frame couter

### DIFF
--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -379,13 +379,17 @@ const GodotEditorEventHandler = {
 		handler_wait_fs_sync_done: async function (ev) {
 			let infos = ev.detail
 			await GodotFS.try_sync()
-			let start_frame = GodotOS.frame_num
+			await GodotEditorEventHandler.wait_fs_sync_done(infos.resolve)
+		},
+
+		wait_fs_sync_done: async function (resolve) {
+			let start_frame = GodotOS._frame_num
 			await GodotOS.get_sync_done_promise()
-			if (GodotOS.frame_num - start_frame < 2) {
+			if (GodotOS._frame_num - start_frame < GodotOS._min_wait_frame_num) {
 				await GodotOS.get_sync_done_promise()
 			}
-			if (infos.resolve) {
-				infos.resolve()
+			if (resolve) {
+				resolve()
 			}
 		},
 
@@ -397,14 +401,7 @@ const GodotEditorEventHandler = {
 			// 2. handle delete files
 			GodotEditorEventHandler.deleteFilesCB(infos.deleteInfos);
 			// 3. callback 
-			let start_frame = GodotOS.frame_num
-			await GodotOS.get_sync_done_promise()
-			if (GodotOS.frame_num - start_frame < 2) {
-				await GodotOS.get_sync_done_promise()
-			}
-			if (infos.resolve) {
-				infos.resolve()
-			}
+			await GodotEditorEventHandler.wait_fs_sync_done(infos.resolve)
 		},
 	},
 	godot_js_delete_files_cb__proxy: 'sync',

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -249,7 +249,9 @@ const GodotOS = {
 		request_quit: function () {},
 		_async_cbs: [],
 		_fs_sync_promise: null,
-		frame_num: 0,
+		_frame_num: 0,
+		// os_web::wait_frame_count = 10 
+		_min_wait_frame_num: 5,
 		_fs_sync_done_promise: null,
 		_fs_sync_done_resove: null,
 
@@ -342,7 +344,7 @@ const GodotOS = {
 	godot_js_os_on_main_iterater__proxy: 'sync',
 	godot_js_os_on_main_iterater__sig: 'vi',
 	godot_js_os_on_main_iterater: function (p_frame_num) {
-		GodotOS.frame_num = p_frame_num;
+		GodotOS._frame_num = p_frame_num;
 	},
 
 	godot_js_os_has_feature__proxy: 'sync',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -77,7 +77,8 @@ void OS_Web::fs_sync_callback() {
 }
 
 bool OS_Web::main_loop_iterate() {
-	uint64_t current_frames_drawn = Engine::get_singleton()->get_frames_drawn();
+	static int current_frames_drawn = 0;
+	current_frames_drawn++;
 	if (is_userfs_persistent() && idb_needs_sync && !idb_is_syncing) {
 		idb_is_syncing = true;
 		idb_needs_sync = false;


### PR DESCRIPTION
Fix “fs_sync” event couter: “fs_sync” event detection relies on `logic frame num` rather than `render frame num` (It's possible to render multiple frames within a single logic frame).
