### PR TITLE
Add function: get_bound_from_alpha

### DIFF
--- a/core/extension/gdextension_spx_ext.cpp
+++ b/core/extension/gdextension_spx_ext.cpp
@@ -179,6 +179,9 @@ static void gdextension_spx_platform_set_debug_mode(GdBool enable) {
 static void gdextension_spx_platform_is_debug_mode(GdBool* ret_val) {
 	*ret_val = platformMgr->is_debug_mode();
 }
+static void gdextension_spx_res_get_bound_from_alpha(GdString path,GdRect2* ret_val) {
+	*ret_val = resMgr->get_bound_from_alpha(path);
+}
 static void gdextension_spx_res_get_image_size(GdString path,GdVec2* ret_val) {
 	*ret_val = resMgr->get_image_size(path);
 }
@@ -639,6 +642,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_platform_is_window_fullscreen);
 	REGISTER_SPX_INTERFACE_FUNC(spx_platform_set_debug_mode);
 	REGISTER_SPX_INTERFACE_FUNC(spx_platform_is_debug_mode);
+	REGISTER_SPX_INTERFACE_FUNC(spx_res_get_bound_from_alpha);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_get_image_size);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_read_all_text);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_has_file);

--- a/core/extension/gdextension_spx_ext.h
+++ b/core/extension/gdextension_spx_ext.h
@@ -241,6 +241,7 @@ typedef void (*GDExtensionSpxPlatformIsWindowFullscreen)(GdBool* ret_value);
 typedef void (*GDExtensionSpxPlatformSetDebugMode)(GdBool enable);
 typedef void (*GDExtensionSpxPlatformIsDebugMode)(GdBool* ret_value);
 // SpxRes
+typedef void (*GDExtensionSpxResGetBoundFromAlpha)(GdString path, GdRect2* ret_value);
 typedef void (*GDExtensionSpxResGetImageSize)(GdString path, GdVec2* ret_value);
 typedef void (*GDExtensionSpxResReadAllText)(GdString path, GdString* ret_value);
 typedef void (*GDExtensionSpxResHasFile)(GdString path, GdBool* ret_value);

--- a/core/extension/spx_camera_mgr.cpp
+++ b/core/extension/spx_camera_mgr.cpp
@@ -48,6 +48,7 @@ void SpxCameraMgr::on_awake() {
 		camera->set_name("SpxCamera2D");
 		get_spx_root()->add_child(camera);
 	}
+	RenderingServer::get_singleton()->set_default_clear_color(Color(1,1,1,1));
 }
 
 GdRect2 SpxCameraMgr::get_viewport_rect() {

--- a/core/extension/spx_res_mgr.cpp
+++ b/core/extension/spx_res_mgr.cpp
@@ -30,8 +30,41 @@
 
 #include "spx_res_mgr.h"
 #include "core/io/file_access.h"
+#include "core/io/image.h"
 #include "scene/main/window.h"
 #include "spx.h"
+
+
+GdRect2 SpxResMgr::get_bound_from_alpha(GdString path) {
+	auto path_str = SpxStr(path);
+
+	Ref<Texture2D> image = ResourceLoader::load(path_str);
+
+	int width = image->get_width();
+	int height = image->get_height();
+
+	int min_x = width;
+	int min_y = height;
+	int max_x = 0;
+	int max_y = 0;
+	bool has_alpha = false;
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			if ( image->is_pixel_opaque(x, y)) { // Check if the pixel is not fully transparent
+				has_alpha = true;
+				if (x < min_x) min_x = x;
+				if (y < min_y) min_y = y;
+				if (x > max_x) max_x = x;
+				if (y > max_y) max_y = y;
+			}
+		}
+	}
+	if (!has_alpha) {
+		return Rect2();
+	}
+
+	return Rect2(Vector2(min_x, min_y), Vector2(max_x - min_x + 1, max_y - min_y + 1));
+}
 
 GdVec2 SpxResMgr::get_image_size(GdString path) {
 	auto path_str = SpxStr(path);

--- a/core/extension/spx_res_mgr.h
+++ b/core/extension/spx_res_mgr.h
@@ -37,6 +37,7 @@
 class SpxResMgr : SpxBaseMgr {
 	SPXCLASS(SpxPlatformMgr, SpxBaseMgr)
 public:
+	GdRect2 get_bound_from_alpha(GdString path);
 	GdVec2 get_image_size(GdString path);
 	GdString read_all_text(GdString path);
 	GdBool has_file(GdString path);

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -219,6 +219,10 @@ void gdspx_platform_is_debug_mode(GdBool* ret_val) {
 	*ret_val = platformMgr->is_debug_mode();
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_res_get_bound_from_alpha(GdString* path,GdRect2* ret_val) {
+	*ret_val = resMgr->get_bound_from_alpha(*path);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_res_get_image_size(GdString* path,GdVec2* ret_val) {
 	*ret_val = resMgr->get_image_size(*path);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -361,6 +361,16 @@ function gdspx_platform_is_debug_mode() {
 	FreeGdBool(_retValue); 
 	return _finalRetValue
 }
+function gdspx_res_get_bound_from_alpha(path) {
+	_gdFuncPtr =  GodotEngine.rtenv['_gdspx_res_get_bound_from_alpha']; 
+	_retValue = AllocGdRect2();
+	_arg0 = ToGdString(path);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdString(_arg0); 
+	_finalRetValue = ToJsRect2(_retValue);
+	FreeGdRect2(_retValue); 
+	return _finalRetValue
+}
 function gdspx_res_get_image_size(path) {
 	_gdFuncPtr =  GodotEngine.rtenv['_gdspx_res_get_image_size']; 
 	_retValue = AllocGdVec2();


### PR DESCRIPTION
Calculate sprite's bounding box by it's default costume's alpha channel

https://github.com/goplus/spx/pull/448