### PR TITLE
Fix boundary calc error when camera zoom is not equal 1

### DIFF
--- a/core/extension/spx_physic_mgr.cpp
+++ b/core/extension/spx_physic_mgr.cpp
@@ -118,7 +118,7 @@ GdInt SpxPhysicMgr::check_touched_camera_boundaries(GdObj obj) {
 
 	Vector2 viewport_size = camera->get_viewport_rect().size;
 	Vector2 zoom = camera->get_zoom();
-	Vector2 half_size = (viewport_size * zoom) * 0.5;
+	Vector2 half_size = (viewport_size / zoom) * 0.5;
 	Vector2 camera_position = camera_transform.get_origin();
 
 	Ref<RectangleShape2D> vertical_edge_shape;

--- a/core/extension/spx_res_mgr.cpp
+++ b/core/extension/spx_res_mgr.cpp
@@ -207,7 +207,6 @@ void SpxResMgr::create_animation(GdString p_sprite_type_name, GdString p_anim_na
 	auto anim_key = get_anim_key_name(sprite_type_name, clip_name);
 	auto frames = anim_frames;
 	if (frames->has_animation(anim_key)) {
-		print_error("animation is already exist " + sprite_type_name + " " + clip_name);
 		return ;
 	}
 	frames->add_animation(anim_key);


### PR DESCRIPTION
- Remove duplicate animation log for scene reload
- Fix boundary calc error when camera zoom is not equal 1