### PR TITLE
Add web crash detection

### DIFF
--- a/core/extension/gdextension_spx_ext.cpp
+++ b/core/extension/gdextension_spx_ext.cpp
@@ -130,6 +130,12 @@ static void gdextension_spx_camera_set_camera_zoom(GdVec2 size) {
 static void gdextension_spx_camera_get_viewport_rect(GdRect2* ret_val) {
 	*ret_val = cameraMgr->get_viewport_rect();
 }
+static void gdextension_spx_ext_request_exit(GdInt exit_code) {
+	 extMgr->request_exit(exit_code);
+}
+static void gdextension_spx_ext_on_runtime_panic(GdString msg) {
+	 extMgr->on_runtime_panic(msg);
+}
 static void gdextension_spx_ext_destroy_all_pens() {
 	 extMgr->destroy_all_pens();
 }
@@ -762,6 +768,8 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_camera_get_camera_zoom);
 	REGISTER_SPX_INTERFACE_FUNC(spx_camera_set_camera_zoom);
 	REGISTER_SPX_INTERFACE_FUNC(spx_camera_get_viewport_rect);
+	REGISTER_SPX_INTERFACE_FUNC(spx_ext_request_exit);
+	REGISTER_SPX_INTERFACE_FUNC(spx_ext_on_runtime_panic);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_destroy_all_pens);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_create_pen);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_destroy_pen);

--- a/core/extension/gdextension_spx_ext.h
+++ b/core/extension/gdextension_spx_ext.h
@@ -193,8 +193,6 @@ typedef struct {
 	
 } SpxCallbackInfo;
 
-
-
 // SpxAudio
 typedef void (*GDExtensionSpxAudioStopAll)();
 typedef void (*GDExtensionSpxAudioCreateAudio)(GdObj* ret_value);
@@ -221,6 +219,8 @@ typedef void (*GDExtensionSpxCameraGetCameraZoom)(GdVec2* ret_value);
 typedef void (*GDExtensionSpxCameraSetCameraZoom)(GdVec2 size);
 typedef void (*GDExtensionSpxCameraGetViewportRect)(GdRect2* ret_value);
 // SpxExt
+typedef void (*GDExtensionSpxExtRequestExit)(GdInt exit_code);
+typedef void (*GDExtensionSpxExtOnRuntimePanic)(GdString msg);
 typedef void (*GDExtensionSpxExtDestroyAllPens)();
 typedef void (*GDExtensionSpxExtCreatePen)(GdObj* ret_value);
 typedef void (*GDExtensionSpxExtDestroyPen)(GdObj obj);

--- a/core/extension/spx_base_mgr.cpp
+++ b/core/extension/spx_base_mgr.cpp
@@ -73,6 +73,9 @@ void SpxBaseMgr::on_start() {
 void SpxBaseMgr::on_update(float delta) {
 }
 
+void SpxBaseMgr::on_exit(int exit_code) {
+}
+
 void SpxBaseMgr::on_fixed_update(float delta) {
 }
 

--- a/core/extension/spx_base_mgr.h
+++ b/core/extension/spx_base_mgr.h
@@ -70,6 +70,7 @@ public:
 	virtual void on_update(float delta);
 	virtual void on_fixed_update(float delta);
 	virtual void on_destroy();
+	virtual void on_exit(int exit_code);
 	virtual ~SpxBaseMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor
 };
 

--- a/core/extension/spx_engine.cpp
+++ b/core/extension/spx_engine.cpp
@@ -45,6 +45,56 @@
 #include "spx_ext_mgr.h"
 SpxEngine *SpxEngine::singleton = nullptr;
 
+void SpxEngine::register_runtime_panic_callbacks(GDExtensionSpxGlobalRuntimePanicCallback callback) {
+	singleton->on_runtime_panic = callback;
+}
+
+static SpxCallbackInfo get_default_spx_callbacks() {
+	SpxCallbackInfo callbacks;
+	callbacks.func_on_engine_start = [](){};
+	callbacks.func_on_engine_fixed_update = [](GdFloat delta){};
+	callbacks.func_on_engine_update = [](GdFloat delta){};
+	callbacks.func_on_engine_destroy = [](){};
+	callbacks.func_on_scene_sprite_instantiated = [](GdObj obj,GdString type_name){};
+	callbacks.func_on_sprite_ready = [](GdObj obj){};
+	callbacks.func_on_sprite_updated = [](GdFloat delta){};
+	callbacks.func_on_sprite_fixed_updated = [](GdFloat delta){};
+	callbacks.func_on_sprite_destroyed = [](GdObj obj){};
+	callbacks.func_on_sprite_frames_set_changed = [](GdObj obj){};
+	callbacks.func_on_sprite_animation_changed = [](GdObj obj){};
+	callbacks.func_on_sprite_frame_changed = [](GdObj obj){};
+	callbacks.func_on_sprite_animation_looped = [](GdObj obj){};
+	callbacks.func_on_sprite_animation_finished = [](GdObj obj){};
+	callbacks.func_on_sprite_vfx_finished = [](GdObj obj){};
+	callbacks.func_on_sprite_screen_exited = [](GdObj obj){};
+	callbacks.func_on_sprite_screen_entered = [](GdObj obj){};
+	callbacks.func_on_mouse_pressed = [](GdInt keyid){};
+	callbacks.func_on_mouse_released = [](GdInt keyid){};
+	callbacks.func_on_key_pressed = [](GdInt keyid){};
+	callbacks.func_on_key_released = [](GdInt keyid){};
+	callbacks.func_on_action_pressed = [](GdString action_name){};
+	callbacks.func_on_action_just_pressed = [](GdString action_name){};
+	callbacks.func_on_action_just_released = [](GdString action_name){};
+	callbacks.func_on_axis_changed = [](GdString action_name, GdFloat value){};
+	callbacks.func_on_collision_enter = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_collision_stay = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_collision_exit = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_trigger_enter = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_trigger_stay = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_trigger_exit = [](GdInt self_id, GdInt other_id){};
+	callbacks.func_on_ui_ready = [](GdObj obj){};
+	callbacks.func_on_ui_updated = [](GdObj obj){};
+	callbacks.func_on_ui_destroyed = [](GdObj obj){};
+	callbacks.func_on_ui_pressed = [](GdObj obj){};
+	callbacks.func_on_ui_released = [](GdObj obj){};
+	callbacks.func_on_ui_hovered = [](GdObj obj){};
+	callbacks.func_on_ui_clicked = [](GdObj obj){};
+	callbacks.func_on_ui_toggle = [](GdObj obj, GdBool is_on){};
+	callbacks.func_on_ui_text_changed = [](GdObj obj, GdString text){};
+	return callbacks;
+}
+
+
 void SpxEngine::register_callbacks(GDExtensionSpxCallbackInfoPtr callback_ptr) {
 	if (singleton != nullptr) {
 		print_error("SpxEngine::register_callbacks failed, already initialed! ");
@@ -103,6 +153,9 @@ void SpxEngine::set_root_node(SceneTree *p_tree, Node *p_node) {
 }
 
 void SpxEngine::on_awake() {
+	if (has_exit) {
+		return;
+	}
 	for (auto mgr : mgrs) {
 		mgr->on_awake();
 	}
@@ -115,6 +168,9 @@ void SpxEngine::on_awake() {
 }
 
 void SpxEngine::on_fixed_update(float delta) {
+	if (has_exit) {
+		return;
+	}
 	for (auto mgr : mgrs) {
 		mgr->on_fixed_update(delta);
 	}
@@ -124,6 +180,9 @@ void SpxEngine::on_fixed_update(float delta) {
 }
 
 void SpxEngine::on_update(float delta) {
+	if (has_exit) {
+		return;
+	}
 	for (auto mgr : mgrs) {
 		mgr->on_update(delta);
 	}
@@ -132,14 +191,28 @@ void SpxEngine::on_update(float delta) {
 	}
 }
 
+void SpxEngine::on_exit(int exit_code) {
+	if (has_exit) {
+		return;
+	}
+	has_exit = true;
+	for (auto mgr : mgrs) {
+		mgr->on_exit(exit_code);
+	}
+	// remove all runtime callbacks
+	callbacks = get_default_spx_callbacks();
+}
+
 void SpxEngine::on_destroy() {
 	for (auto mgr : mgrs) {
 		mgr->on_destroy();
+	}	
+	if (!has_exit) {
+		if (callbacks.func_on_engine_destroy != nullptr) {
+			callbacks.func_on_engine_destroy();
+		}
 	}
-	if (callbacks.func_on_engine_destroy != nullptr) {
-		callbacks.func_on_engine_destroy();
-	}
-	callbacks = SpxCallbackInfo();
+	callbacks = get_default_spx_callbacks();
 	memdelete(input);
 	memdelete(audio);
 	memdelete(physic);

--- a/core/extension/spx_engine.h
+++ b/core/extension/spx_engine.h
@@ -49,13 +49,16 @@ class SpxPlatformMgr;
 class SpxResMgr;
 class SpxExtMgr;
 
+typedef void (*GDExtensionSpxGlobalRuntimePanicCallback)(GdString msg);
+
 class SpxEngine : SpxBaseMgr {
 	static SpxEngine *singleton;
 
 public:
 	static SpxEngine *get_singleton() { return singleton; }
 	static bool has_initialed() { return singleton != nullptr; }
-	static void register_callbacks(GDExtensionSpxCallbackInfoPtr callback_ptr);
+	static void register_callbacks(GDExtensionSpxCallbackInfoPtr callback);
+	static void register_runtime_panic_callbacks(GDExtensionSpxGlobalRuntimePanicCallback callback);
 	virtual ~SpxEngine() = default; 
 
 private:
@@ -88,9 +91,11 @@ private:
 	Node *spx_root;
 	GdInt global_id;
 	SpxCallbackInfo callbacks;
-
+	GDExtensionSpxGlobalRuntimePanicCallback on_runtime_panic;
+	bool has_exit;
 public:
-	SpxCallbackInfo *get_callbacks();
+	SpxCallbackInfo *get_callbacks() ;
+	GDExtensionSpxGlobalRuntimePanicCallback get_on_runtime_panic() { return on_runtime_panic; }
 
 public:
 	GdInt get_unique_id() override;
@@ -103,6 +108,7 @@ public:
 	void on_fixed_update(float delta) override;
 	void on_update(float delta) override;
 	void on_destroy() override;
+	void on_exit(int exit_code) override;
 };
 
 #endif // SPX_ENGINE_H

--- a/core/extension/spx_ext_mgr.cpp
+++ b/core/extension/spx_ext_mgr.cpp
@@ -83,6 +83,21 @@ void SpxExtMgr::on_destroy() {
 	SpxBaseMgr::on_destroy();
 }
 
+void SpxExtMgr::request_exit(GdInt exit_code) {
+	SpxEngine::get_singleton()->on_exit(exit_code);
+	get_tree()->quit(exit_code);
+}
+
+void SpxExtMgr::on_runtime_panic(GdString msg) {
+	auto msg_str = SpxStr(msg);
+	auto callback = SpxEngine::get_singleton()->get_on_runtime_panic();
+	if (callback != nullptr) {
+		auto str = SpxReturnStr(msg_str);
+		callback(str);
+	}
+}
+
+
 SpxPen *SpxExtMgr::_get_pen(GdObj obj) {
 	if (id_pens.has(obj)) {
 		return id_pens[obj];

--- a/core/extension/spx_ext_mgr.h
+++ b/core/extension/spx_ext_mgr.h
@@ -56,6 +56,10 @@ public:
 	void on_update(float delta) override;
 
 public:
+	// engine API
+	void request_exit(GdInt exit_code);
+	void on_runtime_panic(GdString msg);
+
 	// obj APIs
 	void destroy_all_pens();
 	GdObj create_pen();

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -153,6 +153,14 @@ void gdspx_camera_get_viewport_rect(GdRect2* ret_val) {
 	*ret_val = cameraMgr->get_viewport_rect();
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_ext_request_exit(GdInt* exit_code) {
+	 extMgr->request_exit(*exit_code);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_ext_on_runtime_panic(GdString* msg) {
+	 extMgr->on_runtime_panic(*msg);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_ext_destroy_all_pens() {
 	 extMgr->destroy_all_pens();
 }

--- a/platform/web/godot_js_spx.h
+++ b/platform/web/godot_js_spx.h
@@ -13,6 +13,7 @@ typedef uint8_t GdBool ;
 // GDExtention
 extern void godot_js_on_load_gdextension(GdString p_text, void* p_get_proc_address, void* p_library, void* r_initialization);
 
+extern void godot_js_spx_on_runtime_panic(GdString msg);
 // Gdspx 
 extern void godot_js_spx_on_engine_start();
 extern void godot_js_spx_on_engine_update(GdFloat delta);

--- a/platform/web/godot_js_spx_callback.cpp
+++ b/platform/web/godot_js_spx_callback.cpp
@@ -12,6 +12,9 @@
 static void _godot_js_on_load_gdextension(GdString p_text, void* p_get_proc_address, void* p_library, void* r_initialization){
 	godot_js_on_load_gdextension(p_text, p_get_proc_address, p_library, r_initialization);
 }
+static void _godot_js_spx_on_runtime_panic(GdString msg){
+	godot_js_spx_on_runtime_panic(msg);
+}
 static void _godot_js_spx_on_engine_start(){
 	godot_js_spx_on_engine_start();
 }
@@ -27,14 +30,10 @@ static void _godot_js_spx_on_engine_destroy(){
 
 static void _godot_js_spx_on_scene_sprite_instantiated(GdObj obj,GdString type_name){
 	godot_js_spx_on_scene_sprite_instantiated(&obj, type_name);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_sprite_ready(GdObj obj){
 	godot_js_spx_on_sprite_ready(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_updated(GdFloat delta){
 	godot_js_spx_on_sprite_updated(delta);
@@ -44,170 +43,106 @@ static void _godot_js_spx_on_sprite_fixed_updated(GdFloat delta){
 }
 static void _godot_js_spx_on_sprite_destroyed(GdObj obj){
 	godot_js_spx_on_sprite_destroyed(&obj);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_sprite_frames_set_changed(GdObj obj){
 	godot_js_spx_on_sprite_frames_set_changed(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_animation_changed(GdObj obj){
 	godot_js_spx_on_sprite_animation_changed(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_frame_changed(GdObj obj){
 	godot_js_spx_on_sprite_frame_changed(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_animation_looped(GdObj obj){
 	godot_js_spx_on_sprite_animation_looped(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_animation_finished(GdObj obj){
 	godot_js_spx_on_sprite_animation_finished(&obj);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_sprite_vfx_finished(GdObj obj){
 	godot_js_spx_on_sprite_vfx_finished(&obj);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_sprite_screen_exited(GdObj obj){
 	godot_js_spx_on_sprite_screen_exited(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_sprite_screen_entered(GdObj obj){
 	godot_js_spx_on_sprite_screen_entered(&obj);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_mouse_pressed(GdInt keyid){
 	godot_js_spx_on_mouse_pressed(&keyid);
-	if(keyid == 1)
-		return;
 }
 static void _godot_js_spx_on_mouse_released(GdInt keyid){
 	godot_js_spx_on_mouse_released(&keyid);
-	if(keyid == 1)
-		return;
 }
 static void _godot_js_spx_on_key_pressed(GdInt keyid){
 	godot_js_spx_on_key_pressed(&keyid);
-	if(keyid == 1)
-		return;
 }
 static void _godot_js_spx_on_key_released(GdInt keyid){
 	godot_js_spx_on_key_released(&keyid);
-	if(keyid == 1)
-		return;
 }
 static void _godot_js_spx_on_action_pressed(GdString action_name){
 	godot_js_spx_on_action_pressed(action_name);
-	if (action_name != nullptr)
-		return;
 }
 static void _godot_js_spx_on_action_just_pressed(GdString action_name){
 	godot_js_spx_on_action_just_pressed(action_name);
-	if (action_name != nullptr)
-		return;
 }
 static void _godot_js_spx_on_action_just_released(GdString action_name){
 	godot_js_spx_on_action_just_released(action_name);
-	if (action_name != nullptr)
-		return;
 }
 static void _godot_js_spx_on_axis_changed(GdString action_name, GdFloat value){
 	godot_js_spx_on_axis_changed(action_name, value);
-	if (action_name != nullptr)
-		return;
 }
 
 static void _godot_js_spx_on_collision_enter(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_collision_enter(&self_id, &other_id);
-	if(self_id == 1)
-		return;
 }
 static void _godot_js_spx_on_collision_stay(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_collision_stay(&self_id, &other_id);
-	if(self_id == 1)
-		return;
 }
 static void _godot_js_spx_on_collision_exit(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_collision_exit(&self_id, &other_id);
-	if(self_id == 1)
-		return;
 }
 static void _godot_js_spx_on_trigger_enter(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_trigger_enter(&self_id, &other_id);
-	if(self_id == 1)
-		return;
 }
 static void _godot_js_spx_on_trigger_stay(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_trigger_stay(&self_id, &other_id);
-	if(self_id == 1 || other_id == 1)
-		return;
 }
 static void _godot_js_spx_on_trigger_exit(GdInt self_id, GdInt other_id){
 	godot_js_spx_on_trigger_exit(&self_id, &other_id);
-	if(self_id == 1 || other_id == 1)
-		return;
 }
 
 static void _godot_js_spx_on_ui_ready(GdObj obj){
 	godot_js_spx_on_ui_ready(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_updated(GdObj obj){
 	godot_js_spx_on_ui_updated(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_destroyed(GdObj obj){
 	godot_js_spx_on_ui_destroyed(&obj);
-	if(obj == 1)
-		return;
 }
 
 static void _godot_js_spx_on_ui_pressed(GdObj obj){
 	godot_js_spx_on_ui_pressed(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_released(GdObj obj){
 	godot_js_spx_on_ui_released(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_hovered(GdObj obj){
 	godot_js_spx_on_ui_hovered(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_clicked(GdObj obj){
 	godot_js_spx_on_ui_clicked(&obj);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_toggle(GdObj obj, GdBool is_on){
 	godot_js_spx_on_ui_toggle(&obj, is_on);
-	if(obj == 1)
-		return;
 }
 static void _godot_js_spx_on_ui_text_changed(GdObj obj, GdString text){
 	godot_js_spx_on_ui_text_changed(&obj, text);
-	if(obj == 1)
-		return;
 }
 
 
@@ -256,4 +191,5 @@ void OS_Web::register_spx_callbacks() {
 	callback_infos->func_on_ui_text_changed = &_godot_js_spx_on_ui_text_changed;
 	
 	SpxEngine::register_callbacks(callback_infos);
+	SpxEngine::register_runtime_panic_callbacks(_godot_js_spx_on_runtime_panic);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -217,6 +217,22 @@ function gdspx_camera_get_viewport_rect() {
 	FreeGdRect2(_retValue); 
 	return _finalRetValue
 }
+function gdspx_ext_request_exit(exit_code) {
+	var _gdFuncPtr =  GodotEngine.rtenv['_gdspx_ext_request_exit']; 
+	
+	var _arg0 = ToGdInt(exit_code);
+	_gdFuncPtr(_arg0);
+	FreeGdInt(_arg0); 
+
+}
+function gdspx_ext_on_runtime_panic(msg) {
+	var _gdFuncPtr =  GodotEngine.rtenv['_gdspx_ext_on_runtime_panic']; 
+	
+	var _arg0 = ToGdString(msg);
+	_gdFuncPtr(_arg0);
+	FreeGdString(_arg0); 
+
+}
 function gdspx_ext_destroy_all_pens() {
 	var _gdFuncPtr =  GodotEngine.rtenv['_gdspx_ext_destroy_all_pens']; 
 	

--- a/platform/web/js/libs/library_godot_gdspx.js
+++ b/platform/web/js/libs/library_godot_gdspx.js
@@ -62,6 +62,13 @@ const GodotGdspx = {
 	godot_js_spx_on_scene_sprite_instantiated: function (obj, type_name) {
 		window.gdspx_on_scene_sprite_instantiated(GodotRuntime.ToJsObj(obj), GodotRuntime.parseString(type_name));
 	},
+	
+	godot_js_spx_on_runtime_panic__proxy: 'sync',
+	godot_js_spx_on_runtime_panic__sig: 'vi',
+	godot_js_spx_on_runtime_panic: function (msg) {
+		window.gdspx_on_runtime_panic(GodotRuntime.parseString(msg));
+	},
+	
 
 	godot_js_spx_on_sprite_ready__proxy: 'sync',
 	godot_js_spx_on_sprite_ready__sig: 'vi',


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/652
test project: [test_panic.zip](https://github.com/user-attachments/files/20436554/test_panic.zip)
test script:
```go
import "fmt"
onStart => {
	id := 0
	for {
		id++
		say fmt.Sprintf("Hello, click panic, space to exit %d", id)
		wait 0.3
	}
}
onClick => {
	panic("bbb")
}
onKey KeySpace, => {
	println("space to exit")
	exit()
}

// test infinity loop
for {
}
```


https://github.com/user-attachments/assets/e14a9f67-14ee-4058-936f-726f3fd0a361





