### PR TITLE
Fix string init error

### DIFF
--- a/core/extension/spx_audio_bus_pool.cpp
+++ b/core/extension/spx_audio_bus_pool.cpp
@@ -39,9 +39,9 @@
 
 // Initialize static members
 SpxAudioBusPool *SpxAudioBusPool::singleton = nullptr;
-const StringName SpxAudioBusPool::STR_BUS_MASTER = "Master";
-const StringName SpxAudioBusPool::STR_BUS_SFX = "Sfx";
-const StringName SpxAudioBusPool::STR_BUS_MUSIC = "Music";
+StringName SpxAudioBusPool::STR_BUS_MASTER;
+StringName SpxAudioBusPool::STR_BUS_SFX;
+StringName SpxAudioBusPool::STR_BUS_MUSIC;
 
 
 SpxAudioBusPool *SpxAudioBusPool::get_singleton() {
@@ -59,6 +59,11 @@ StringName SpxAudioBusPool::get_bus_name(int id) {
 	return String::num_real(id);
 }
 void SpxAudioBusPool::init() {
+
+	SpxAudioBusPool::STR_BUS_MASTER = "Master";
+	SpxAudioBusPool::STR_BUS_SFX = "Sfx";
+	SpxAudioBusPool::STR_BUS_MUSIC = "Music";
+
 	singleton = memnew(SpxAudioBusPool);
 	// Start with DEFAULT_BUS_COUNT buses (includes master)
 	AudioServer::get_singleton()->set_bus_count(DEFAULT_BUS_COUNT);

--- a/core/extension/spx_audio_bus_pool.h
+++ b/core/extension/spx_audio_bus_pool.h
@@ -42,9 +42,9 @@ public:
 	static const int BUS_MASTER = 0;
 	static const int BUS_SFX = 1;
 	static const int BUS_MUSIC = 2;
-	static const StringName STR_BUS_MASTER;
-	static const StringName STR_BUS_SFX;
-	static const StringName STR_BUS_MUSIC;
+	static StringName STR_BUS_MASTER;
+	static StringName STR_BUS_SFX;
+	static StringName STR_BUS_MUSIC;
 
 private:
 	static const int DEFAULT_BUS_COUNT = 4; // Default number of buses including master

--- a/core/extension/spx_sprite_mgr.cpp
+++ b/core/extension/spx_sprite_mgr.cpp
@@ -50,7 +50,7 @@
 
 #define DEFAULT_COLLISION_ALPHA_THRESHOLD 0.05
 
-StringName SpxSpriteMgr::default_texture_anim = "";
+StringName SpxSpriteMgr::default_texture_anim;
 #define check_and_get_sprite_r(VALUE) \
 	auto sprite = get_sprite(obj);\
 	if (sprite == nullptr) {\
@@ -358,7 +358,7 @@ void SpxSpriteMgr::set_material_shader(GdObj obj, GdString path) {
 }
 
 GdString SpxSpriteMgr::get_material_shader(GdObj obj) {
-	check_and_get_sprite_r(GdString()) 
+	check_and_get_sprite_r(GdString())
 	return sprite->get_material_shader();
 }
 


### PR DESCRIPTION
Fix error of :
```
ERROR: Condition "!configured" is true.
   at: StringName::StringName (core\string\string_name.cpp:213)
ERROR: Condition "!configured" is true.
   at: StringName::StringName (core\string\string_name.cpp:213)
ERROR: Condition "!configured" is true.
   at: StringName::StringName (core\string\string_name.cpp:213)
ERROR: Condition "!configured" is true.
   at: StringName::StringName (core\string\string_name.cpp:213)
```