### PR TITLE
Add feat: dynamic load external font and set as default font

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -23,11 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, linker=lld)
             cache-name: linux-editor-double-sanitizers
             target: editor
             # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
-            sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=gold
+            sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double linker=lld use_llvm=yes
             bin: "./bin/godot.linuxbsd.editor.dev.double.x86_64.san"
             build-mono: false
             tests: true
@@ -60,7 +60,7 @@ jobs:
           - name: Template (target=template_release)
             cache-name: linux-template
             target: template_release
-            sconsflags: module_mono_enabled=false
+            sconsflags: module_mono_enabled=false use_llvm=yes linker=lld
             build-mono: false
             tests: false
             artifact: true

--- a/core/extension/gdextension_spx_ext.cpp
+++ b/core/extension/gdextension_spx_ext.cpp
@@ -286,6 +286,9 @@ static void gdextension_spx_res_reload_texture(GdString path) {
 static void gdextension_spx_res_free_str(GdString str) {
 	 resMgr->free_str(str);
 }
+static void gdextension_spx_res_set_default_font(GdString font_path) {
+	 resMgr->set_default_font(font_path);
+}
 static void gdextension_spx_scene_change_scene_to_file(GdString path) {
 	 sceneMgr->change_scene_to_file(path);
 }
@@ -823,6 +826,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_has_file);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_reload_texture);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_free_str);
+	REGISTER_SPX_INTERFACE_FUNC(spx_res_set_default_font);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_change_scene_to_file);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_destroy_all_sprites);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_reload_current_scene);

--- a/core/extension/gdextension_spx_ext.h
+++ b/core/extension/gdextension_spx_ext.h
@@ -277,6 +277,7 @@ typedef void (*GDExtensionSpxResReadAllText)(GdString p_path, GdString* ret_valu
 typedef void (*GDExtensionSpxResHasFile)(GdString p_path, GdBool* ret_value);
 typedef void (*GDExtensionSpxResReloadTexture)(GdString path);
 typedef void (*GDExtensionSpxResFreeStr)(GdString str);
+typedef void (*GDExtensionSpxResSetDefaultFont)(GdString font_path);
 // SpxScene
 typedef void (*GDExtensionSpxSceneChangeSceneToFile)(GdString path);
 typedef void (*GDExtensionSpxSceneDestroyAllSprites)();

--- a/core/extension/spx_res_mgr.cpp
+++ b/core/extension/spx_res_mgr.cpp
@@ -40,12 +40,18 @@
 #include "scene/resources/audio_stream_wav.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/sprite_frames.h"
+#include "scene/theme/default_theme.h"
+#include "scene/theme/theme_db.h"
 #include "spx_engine.h"
 #include "spx_importer_wav.h"
 #include "spx_platform_mgr.h"
 #ifdef TOOLS_ENABLED
 #include "editor/import/resource_importer_wav.h"
 #include "modules/minimp3/resource_importer_mp3.h"
+#endif
+
+#ifdef MODULE_SVG_ENABLED
+#include "modules/svg/svg_utils.h"
 #endif
 
 #define platformMgr SpxEngine::get_singleton()->get_platform()
@@ -363,4 +369,39 @@ GdBool SpxResMgr::has_file(GdString p_path) {
 	path = _to_engine_path(path);
 	Ref<FileAccess> file = FileAccess::open(path, FileAccess::READ);
 	return !file.is_null();
+}
+
+
+void SpxResMgr::set_default_font(GdString font_path) {
+	String path = SpxStr(font_path);
+	String engine_path = _to_engine_path(path);
+	Ref<FileAccess> f = FileAccess::open(engine_path, FileAccess::READ);
+	if (f.is_null()) {
+		ERR_PRINT("Can not open font file: " + path + " engine_path= " + engine_path );
+		return ;
+	}
+
+	Vector<uint8_t> font_data;
+	font_data.resize(f->get_length());
+	f->get_buffer(font_data.ptrw(), font_data.size());
+
+	// update svg
+#ifdef MODULE_SVG_ENABLED
+	SVGUtils::set_default_font(font_data.ptrw(), (int)font_data.size());
+#endif
+
+	// update theme
+	Ref<FontFile> font;
+	font.instantiate();
+	font->set_font_style(0);
+	font->set_data(font_data);
+	font->set_antialiasing(TextServer::FONT_ANTIALIASING_GRAY);
+	font->set_force_autohinter(false);
+	font->set_hinting(TextServer::HINTING_LIGHT);
+	font->set_subpixel_positioning(TextServer::SUBPIXEL_POSITIONING_AUTO);
+	font->set_multichannel_signed_distance_field(false);
+	font->set_generate_mipmaps(false);
+	font->set_fixed_size(0);
+	font->set_allow_system_fallback(true);
+	ThemeDB::get_singleton()->set_default_font(font);
 }

--- a/core/extension/spx_res_mgr.h
+++ b/core/extension/spx_res_mgr.h
@@ -35,6 +35,7 @@
 #include "scene/resources/sprite_frames.h"
 #include "servers/audio/audio_stream.h"
 #include "spx_base_mgr.h"
+#include "scene/resources/font.h"
 
 class AudioStreamMP3;
 class AudioStreamWAV;
@@ -69,7 +70,6 @@ public:
 	Ref<SpriteFrames> get_anim_frames(const String& anim_name);
 	String get_anim_key_name(const String& sprite_type_name,const String& anim_name);
 	bool is_dynamic_anim_mode() const;
-
 public:
 	void create_animation(GdString sprite_type_name,GdString anim_name, GdString context, GdInt fps, GdBool is_altas);
 
@@ -81,6 +81,7 @@ public:
 	GdBool has_file(GdString p_path);
 	void reload_texture(GdString path);
 	void free_str(GdString str);
+	void set_default_font(GdString font_path);
 };
 
 #endif // SPX_RES_MGR_H

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -92,10 +92,9 @@ thirdparty_sources2 = [
     "source/svgrenderstate.cpp",
     "source/svgtextelement.cpp",
 ]
-# enable embedded font for web
-if env_svg['platform'] == 'web':
-    env_svg.Append(CPPDEFINES=["LUNASVG_ENABLE_EMBEDDED_FONTS"])
-    thirdparty_sources2 = thirdparty_sources2 + ["source/embedded_cnfont.cpp"]
+# enable embedded font for all platforms (needed for SVGUtils::set_default_font)
+env_svg.Append(CPPDEFINES=["LUNASVG_ENABLE_EMBEDDED_FONTS"])
+thirdparty_sources2 = thirdparty_sources2 + ["source/embedded_cnfont.cpp"]
 
 thirdparty_sources2 = [thirdparty_dir2 + file for file in thirdparty_sources2]
 

--- a/modules/svg/svg_utils.cpp
+++ b/modules/svg/svg_utils.cpp
@@ -1,0 +1,8 @@
+﻿#include "svg_utils.h"
+#include "thirdparty/lunasvg/include/lunasvg.h"
+
+#include <lunasvg.h>
+
+void SVGUtils::set_default_font(const void *font_data, int length) {
+	lunasvg_add_font_face_from_data("", false, false, font_data, length, nullptr, nullptr);
+}

--- a/modules/svg/svg_utils.h
+++ b/modules/svg/svg_utils.h
@@ -1,0 +1,9 @@
+﻿#ifndef SVG_UTILS_H
+#define SVG_UTILS_H
+
+class SVGUtils {
+public:
+	static void set_default_font(const void *font_data, int length);
+};
+
+#endif // SVG_UTILS_H

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -361,6 +361,10 @@ void gdspx_res_free_str(GdString* str) {
 	 resMgr->free_str(*str);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_res_set_default_font(GdString* font_path) {
+	 resMgr->set_default_font(*font_path);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_scene_change_scene_to_file(GdString* path) {
 	 sceneMgr->change_scene_to_file(*path);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -709,6 +709,14 @@ function gdspx_res_free_str(str) {
 	FreeGdString(_arg0); 
 
 }
+function gdspx_res_set_default_font(font_path) {
+	var _gdFuncPtr =  GodotEngine.rtenv['_gdspx_res_set_default_font']; 
+	
+	var _arg0 = ToGdString(font_path);
+	_gdFuncPtr(_arg0);
+	FreeGdString(_arg0); 
+
+}
 function gdspx_scene_change_scene_to_file(path) {
 	var _gdFuncPtr =  GodotEngine.rtenv['_gdspx_scene_change_scene_to_file']; 
 	

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -99,6 +99,11 @@ void ThemeDB::initialize_theme_noproject() {
 
 	_init_default_theme_context();
 }
+void ThemeDB::set_default_font(Ref<Font> font) {
+	_finalize_theme_contexts();
+	make_default_theme(1.0, font);
+	_init_default_theme_context();
+}
 
 void ThemeDB::finalize_theme() {
 	if (!RenderingServer::get_singleton()) {

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -118,6 +118,7 @@ protected:
 public:
 	void initialize_theme();
 	void initialize_theme_noproject();
+	void set_default_font(Ref<Font> font);
 	void finalize_theme();
 
 	// Global Theme resources.

--- a/thirdparty/lunasvg/source/graphics.cpp
+++ b/thirdparty/lunasvg/source/graphics.cpp
@@ -491,7 +491,6 @@ FontFaceCache::FontFaceCache()
     if (!cnFont.isNull()) {
         addFontFace("", false, false, cnFont);
     }
-    printf("=====>Embedded font loaded\n");
 #endif
 
 }


### PR DESCRIPTION
issue: https://github.com/goplus/spx/pull/689
Added a dynamic loading mechanism for default fonts, with special adaptation for SVG