### PR TITLE
Feat: add onExit callback

### DIFF
--- a/core/extension/spx_engine.cpp
+++ b/core/extension/spx_engine.cpp
@@ -49,6 +49,10 @@ void SpxEngine::register_runtime_panic_callbacks(GDExtensionSpxGlobalRuntimePani
 	singleton->on_runtime_panic = callback;
 }
 
+void SpxEngine::register_runtime_exit_callbacks(GDExtensionSpxGlobalRuntimeExitCallback callback) {
+	singleton->on_runtime_exit = callback;
+}
+
 static SpxCallbackInfo get_default_spx_callbacks() {
 	SpxCallbackInfo callbacks;
 	callbacks.func_on_engine_start = [](){};

--- a/core/extension/spx_engine.h
+++ b/core/extension/spx_engine.h
@@ -50,6 +50,7 @@ class SpxResMgr;
 class SpxExtMgr;
 
 typedef void (*GDExtensionSpxGlobalRuntimePanicCallback)(GdString msg);
+typedef void (*GDExtensionSpxGlobalRuntimeExitCallback)(GdInt code);
 
 class SpxEngine : SpxBaseMgr {
 	static SpxEngine *singleton;
@@ -59,7 +60,8 @@ public:
 	static bool has_initialed() { return singleton != nullptr; }
 	static void register_callbacks(GDExtensionSpxCallbackInfoPtr callback);
 	static void register_runtime_panic_callbacks(GDExtensionSpxGlobalRuntimePanicCallback callback);
-	virtual ~SpxEngine() = default; 
+	static void register_runtime_exit_callbacks(GDExtensionSpxGlobalRuntimeExitCallback callback);
+	virtual ~SpxEngine() = default;
 
 private:
 	Vector<SpxBaseMgr *> mgrs;
@@ -92,10 +94,12 @@ private:
 	GdInt global_id;
 	SpxCallbackInfo callbacks;
 	GDExtensionSpxGlobalRuntimePanicCallback on_runtime_panic;
+	GDExtensionSpxGlobalRuntimeExitCallback on_runtime_exit;
 	bool has_exit;
 public:
 	SpxCallbackInfo *get_callbacks() ;
 	GDExtensionSpxGlobalRuntimePanicCallback get_on_runtime_panic() { return on_runtime_panic; }
+	GDExtensionSpxGlobalRuntimeExitCallback get_on_runtime_exit() { return on_runtime_exit; }
 
 public:
 	GdInt get_unique_id() override;

--- a/core/extension/spx_ext_mgr.cpp
+++ b/core/extension/spx_ext_mgr.cpp
@@ -84,6 +84,11 @@ void SpxExtMgr::on_destroy() {
 }
 
 void SpxExtMgr::request_exit(GdInt exit_code) {
+	auto callback = SpxEngine::get_singleton()->get_on_runtime_exit();
+	if (callback != nullptr) {
+		callback(exit_code);
+	}	
+	
 	SpxEngine::get_singleton()->on_exit(exit_code);
 	get_tree()->quit(exit_code);
 }
@@ -96,7 +101,6 @@ void SpxExtMgr::on_runtime_panic(GdString msg) {
 		callback(str);
 	}
 }
-
 
 SpxPen *SpxExtMgr::_get_pen(GdObj obj) {
 	if (id_pens.has(obj)) {

--- a/platform/web/godot_js_spx.h
+++ b/platform/web/godot_js_spx.h
@@ -14,6 +14,7 @@ typedef uint8_t GdBool ;
 extern void godot_js_on_load_gdextension(GdString p_text, void* p_get_proc_address, void* p_library, void* r_initialization);
 
 extern void godot_js_spx_on_runtime_panic(GdString msg);
+extern void godot_js_spx_on_runtime_exit(int code);
 // Gdspx 
 extern void godot_js_spx_on_engine_start();
 extern void godot_js_spx_on_engine_update(GdFloat delta);

--- a/platform/web/godot_js_spx_callback.cpp
+++ b/platform/web/godot_js_spx_callback.cpp
@@ -15,6 +15,10 @@ static void _godot_js_on_load_gdextension(GdString p_text, void* p_get_proc_addr
 static void _godot_js_spx_on_runtime_panic(GdString msg){
 	godot_js_spx_on_runtime_panic(msg);
 }
+static void _godot_js_spx_on_runtime_exit(GdInt code){
+	godot_js_spx_on_runtime_exit((int)code);
+}
+
 static void _godot_js_spx_on_engine_start(){
 	godot_js_spx_on_engine_start();
 }
@@ -192,4 +196,5 @@ void OS_Web::register_spx_callbacks() {
 	
 	SpxEngine::register_callbacks(callback_infos);
 	SpxEngine::register_runtime_panic_callbacks(_godot_js_spx_on_runtime_panic);
+	SpxEngine::register_runtime_exit_callbacks(_godot_js_spx_on_runtime_exit);
 }

--- a/platform/web/js/libs/library_godot_gdspx.js
+++ b/platform/web/js/libs/library_godot_gdspx.js
@@ -66,9 +66,20 @@ const GodotGdspx = {
 	godot_js_spx_on_runtime_panic__proxy: 'sync',
 	godot_js_spx_on_runtime_panic__sig: 'vi',
 	godot_js_spx_on_runtime_panic: function (msg) {
+		if (!window.gdspx_on_runtime_panic) {
+			return;
+		}
 		window.gdspx_on_runtime_panic(GodotRuntime.parseString(msg));
 	},
-	
+
+	godot_js_spx_on_runtime_exit__proxy: 'sync',
+	godot_js_spx_on_runtime_exit__sig: 'vi',
+	godot_js_spx_on_runtime_exit: function (code) {
+		if (!window.gdspx_on_runtime_exit) {
+			return;
+		}
+		window.gdspx_on_runtime_exit(code);
+	},
 
 	godot_js_spx_on_sprite_ready__proxy: 'sync',
 	godot_js_spx_on_sprite_ready__sig: 'vi',


### PR DESCRIPTION
issue: https://github.com/goplus/spx/issues/735
test project: [test.zip](https://github.com/user-attachments/files/21596624/test.zip)

```
onStart => {
	say "Hello XGo"
	wait 1
	println("try kill")
	exit 1
	println("try killed")
	say "aaaa"
	for {
		wait 1
		say "aa"
		println "aaa"
	}
}

```

<img width="1273" height="497" alt="image" src="https://github.com/user-attachments/assets/e1895ddb-2d04-4bf0-9ba8-9f5e9d5d0b2e" />

