### PR TITLE
Fix macos sdk build error

### DIFF
--- a/drivers/metal/metal_device_properties.mm
+++ b/drivers/metal/metal_device_properties.mm
@@ -316,14 +316,17 @@ void MetalDeviceProperties::init_limits(id<MTLDevice> p_device) {
 
 	limits.maxDrawIndexedIndexValue = std::numeric_limits<uint32_t>::max() - 1;
 
+	// Use default values to avoid compilation issues with missing methods in older SDKs
+	limits.temporalScalerInputContentMinScale = 1.0;
+	limits.temporalScalerInputContentMaxScale = 3.0;
+	
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) ||  (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) || (__TV_OS_VERSION_MAX_ALLOWED >= 170000) 
 	if (@available(macOS 14.0, iOS 17.0, tvOS 17.0, *)) {
 		limits.temporalScalerInputContentMinScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMinScaleForDevice:p_device];
 		limits.temporalScalerInputContentMaxScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMaxScaleForDevice:p_device];
-	} else {
-		// Defaults taken from macOS 14+
-		limits.temporalScalerInputContentMinScale = 1.0;
-		limits.temporalScalerInputContentMaxScale = 3.0;
-	}
+	} 
+#endif
+
 }
 
 MetalDeviceProperties::MetalDeviceProperties(id<MTLDevice> p_device) {

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -97,6 +97,17 @@
 #define MTLVertexFormatFloatRGB9E5 MTLVertexFormatInvalid
 #endif
 
+// define 
+#define MTLGPUFamilyApple1 (MTLGPUFamily)1001
+#define MTLGPUFamilyApple2 (MTLGPUFamily)1002
+#define MTLGPUFamilyApple3 (MTLGPUFamily)1003
+#define MTLGPUFamilyApple4 (MTLGPUFamily)1004
+#define MTLGPUFamilyApple5 (MTLGPUFamily)1005
+#define MTLGPUFamilyApple6 (MTLGPUFamily)1006
+#define MTLGPUFamilyApple7 (MTLGPUFamily)1007
+#define MTLGPUFamilyApple8 (MTLGPUFamily)1008
+#define MTLGPUFamilyApple9 (MTLGPUFamily)1009
+
 template <typename T>
 void clear(T *p_val, size_t p_count = 1) {
 	memset(p_val, 0, sizeof(T) * p_count);

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -314,7 +314,9 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create(const TextureFormat &p
 
 	if (@available(macOS 14.0, iOS 17.0, tvOS 17.0, *)) {
 		if (format_caps & kMTLFmtCapsAtomic) {
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) ||  (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) || (__TV_OS_VERSION_MAX_ALLOWED >= 170000) 
 			desc.usage |= MTLTextureUsageShaderAtomic;
+#endif
 		}
 	}
 


### PR DESCRIPTION
build logs:
``` 
% make initdev
chmod +x ./pkg/gdspx/tools/*.sh && \
	echo "===>step1/5: cmd" && make install && \
	echo "===>step2/5: wasm" && make build-wasm && \
	echo "===>step3/5: pce" && make build-editor && \
	echo "===>step4/5: pc" && make build-desktop && \
	echo "===>step5/5: web" && make build-web && \
	echo "===>initdev done,use `make run` to run demo"
===>step1/5: cmd
cd ./cmd/gox/ && ./install.sh && cd /Users/xushiwei/work/spx 
go: downloading github.com/goplus/spbase v0.1.0
===>step2/5: wasm
cd ./cmd/gox/ && ./install.sh --web && cd /Users/xushiwei/work/spx 
Generating ispx wraps...
Building with basic version...
gdspx.wasm has been created
===>step3/5: pce
make install &&\
	./pkg/gdspx/tools/build_engine.sh -e
cd ./cmd/gox/ && ./install.sh && cd /Users/xushiwei/work/spx 
xgo v1.5.0 devel darwin/arm64
go version go1.24.2 darwin/arm64
version=2.1.5 GOPATH=/Users/xushiwei/go
PROJ_DIR=/Users/xushiwei/work/spx/pkg/gdspx/tools/common/../..
ENGINE_DIR=/Users/xushiwei/work/spx/pkg/gdspx/tools/common/../../godot
ENGINE_VERSION=4.4.1.stable
GOPATH=/Users/xushiwei/go
VERSION=2.1.5
Detecting platform...
Darwin
Platform: macos
Architecture: arm64
Destination directory: /Users/xushiwei/Library/Application Support/Godot/export_templates/4.4.1.stable
Source tag: spx2.1.5
3.12.3 | packaged by Anaconda, Inc. | (main, May  6 2024, 14:46:42) [Clang 14.0.6 ]
Requirement already satisfied: scons==4.7.0 in /Users/xushiwei/miniconda3/envs/llgo_env/lib/python3.12/site-packages (4.7.0)
SCons by Steven Knight et al.:
	SCons: v4.7.0.265be6883fadbb5a545612265acc919595158366, Sun, 17 Mar 2024 17:33:54 -0700, by bdbaddog on M1Dog2021
	SCons path: ['/Users/xushiwei/miniconda3/envs/llgo_env/lib/python3.12/site-packages/SCons']
Copyright (c) 2001 - 2024 The SCons Foundation
Godot directory already exists.
try to install macos vulkan sdk
Error: Could not find jq command. Is jq installed? Try running "brew install jq" or "port install jq" and rerunning this script.
==========
VULKANINFO
==========

Vulkan Instance Version: 1.4.309


Instance Extensions: count = 17
-------------------------------
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_headless_surface                : extension revision 1
VK_EXT_layer_settings                  : extension revision 2
VK_EXT_metal_surface                   : extension revision 1
VK_EXT_surface_maintenance1            : extension revision 1
VK_EXT_swapchain_colorspace            : extension revision 5
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_portability_enumeration         : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_LUNARG_direct_driver_loading        : extension revision 1
VK_MVK_macos_surface                   : extension revision 3

Instance Layers: count = 7
--------------------------
VK_LAYER_KHRONOS_profiles         Khronos Profiles layer                     1.4.309  version 1
VK_LAYER_KHRONOS_shader_object    Khronos Shader object layer                1.4.309  version 1
VK_LAYER_KHRONOS_synchronization2 Khronos Synchronization2 layer             1.4.309  version 1
VK_LAYER_KHRONOS_validation       Khronos Validation Layer                   1.4.309  version 1
VK_LAYER_LUNARG_api_dump          LunarG API dump layer                      1.4.309  version 2
VK_LAYER_LUNARG_gfxreconstruct    GFXReconstruct Capture Layer Version 1.0.5 1.4.309  version 4194309
VK_LAYER_LUNARG_screenshot        LunarG image capture layer                 1.4.309  version 1

Devices:
========
GPU0:
	apiVersion         = 1.2.296
	driverVersion      = 0.2.2019
	vendorID           = 0x106b
	deviceID           = 0xd000207
	deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName         = Apple M1 Pro
	driverID           = DRIVER_ID_MOLTENVK
	driverName         = MoltenVK
	driverInfo         = 1.2.11
	conformanceVersion = 0.0.0.0
	deviceUUID         = 0000106b-0d00-0207-0000-000000000000
	driverUUID         = 4d564b00-0000-27e3-0d00-020700000000
scons: Reading SConscript files ...
Automatically detected platform: macos
Auto-detected 10 CPU cores available for build parallelism. Using 9 cores by default. You can override it with the `-j` or `num_jobs` arguments.
Building for macOS 11.0+.
Building for platform "macos", architecture "arm64", target "editor".
INFO: Developer build, with debug optimization level and debug symbols (unless overridden). 
Checking for C header file mntent.h... (cached) no
scons: done reading SConscript files.
scons: Building targets ...
Compiling drivers/metal/metal_device_properties.mm ...
Compiling drivers/metal/pixel_formats.mm ...
Compiling drivers/metal/rendering_device_driver_metal.mm ...
Compiling editor/editor_resource_preview.cpp ...
Compiling editor/editor_run.cpp ...
Compiling editor/editor_run_native.cpp ...
Compiling editor/editor_script.cpp ...
Compiling editor/editor_sectioned_inspector.cpp ...
Compiling editor/editor_settings.cpp ...
drivers/metal/pixel_formats.mm:576:41: warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension [-Wc99-designator]
  576 |         _mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:576:70: note: first non-designated initializer is here
  576 |         _mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:777:42: warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension [-Wc99-designator]
  777 |         _mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTLPixelFormatInvalid, name };
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:777:72: note: first non-designated initializer is here
  777 |         _mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTLPixelFormatInvalid, name };
      |                                                                               ^~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:892:51: error: use of undeclared identifier 'MTLGPUFamilyApple9'
  892 |         bool iosOnly8 = notMac && p_feat.highestFamily < MTLGPUFamilyApple9;
      |                                                          ^
drivers/metal/pixel_formats.mm:928:62: error: use of undeclared identifier 'MTLGPUFamilyApple9'
  928 |         bool atomic64 = noVulkanSupport && (p_feat.highestFamily >= MTLGPUFamilyApple9 || (p_feat.highestFamily >= MTLGPUFamilyApple8 && p_feat.supportsMac));
      |                                                                     ^
2 warnings and 2 errors generated.
scons: *** [drivers/metal/pixel_formats.macos.editor.dev.arm64.o] Error 1
drivers/metal/metal_device_properties.mm:320:86: error: no known class method for selector 'supportedInputContentMinScaleForDevice:'
  320 |                 limits.temporalScaMTLTextureUsageShaderAtomic
lerInputContentMinScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMinScaleForDevice:p_device];
      |                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/metal_device_properties.mm:320:47: error: C-style cast from 'id' to 'double' is not allowed
  320 |                 limits.temporalScalerInputContentMinScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMinScaleForDevice:p_device];
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/metal_device_properties.mm:321:86: error: no known class method for selector 'supportedInputContentMaxScaleForDevice:'
  321 |                 limits.temporalScalerInputContentMaxScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMaxScaleForDevice:p_device];
      |                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/metal_device_properties.mm:321:47: error: C-style cast from 'id' to 'double' is not allowed
  321 |                 limits.temporalScalerInputContentMaxScale = (double)[MTLFXTemporalScalerDescriptor supportedInputContentMaxScaleForDevice:p_device];
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 errors generated.
scons: *** [drivers/metal/metal_device_properties.macos.editor.dev.arm64.o] Error 1
drivers/metal/rendering_device_driver_metal.mm:317:18: error: use of undeclared identifier 'MTLTextureUsageShaderAtomic'
  317 |                         desc.usage |= MTLTextureUsageShaderAtomic;
      |                                       ^
drivers/metal/rendering_device_driver_metal.mm:3139:3: warning: array designators are a C99 extension [-Wc99-designator]
 3139 |                 [ATTACHMENT_LOAD_OP_LOAD] = MTLLoadActionLoad,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/rendering_device_driver_metal.mm:3145:3: warning: array designators are a C99 extension [-Wc99-designator]
 3145 |                 [ATTACHMENT_STORE_OP_STORE] = MTLStoreActionStore,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings and 1 error generated.
scons: *** [drivers/metal/rendering_device_driver_metal.macos.editor.dev.arm64.o] Error 1
scons: building terminated because of errors.
INFO: Time elapsed: 00:00:08.33 
Destination binary path: /Users/xushiwei/go/bin/gdspx2.1.5
cp: bin/godot.macos.editor.dev.arm64: No such file or directory
make[1]: *** [pce] Error 1
make: *** [initdev] Error 2

```
