### PR TITLE
Feat: bridge wrap code support array type

### DIFF
--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -52,6 +52,23 @@ typedef Vector2 GdVec2;
 typedef Color GdColor;
 typedef Rect2 GdRect2;
 
+typedef struct {
+    int32_t size;
+    int32_t type;
+    void* data;
+} GdArrayInfo;
+
+typedef GdArrayInfo* GdArray;
+
+typedef enum  {
+    GD_ARRAY_TYPE_UNKNOWN = 0,
+    GD_ARRAY_TYPE_INT64 = 1,
+    GD_ARRAY_TYPE_FLOAT = 2,
+	GD_ARRAY_TYPE_BOOL = 3,
+	GD_ARRAY_TYPE_STRING = 4,
+	GD_ARRAY_TYPE_BYTE = 5,
+	GD_ARRAY_TYPE_GDOBJ = 6,
+} GdArrayType;
 
 typedef struct {
 	// 0 is return value

--- a/modules/spx/spx_base_mgr.h
+++ b/modules/spx/spx_base_mgr.h
@@ -53,12 +53,31 @@ public:                               \
 
 #define NULL_OBJECT_ID 0
 
+// GdArray support
+#define GD_ARRAY_TYPE_UNKNOWN  0
+#define GD_ARRAY_TYPE_INT64    1
+#define GD_ARRAY_TYPE_FLOAT    2
+#define GD_ARRAY_TYPE_BOOL     3
+#define GD_ARRAY_TYPE_STRING   4
+#define GD_ARRAY_TYPE_BYTE     5
+#define GD_ARRAY_TYPE_GDOBJ    6
+
 class Window;
 class SceneTree;
 class SpxBaseMgr {
+private:
+	static void* _get_array(GdArray array, int64_t index, int type_size);
+
 public:
 	static GdString to_return_cstr(const String& ret_val);
 	static void free_return_cstr(GdString ret_val);
+	static GdArray create_array(int32_t type, int32_t size);
+	static void free_array(GdArray array);
+
+	template <typename T>
+	static void set_array(GdArray array, int64_t index, T value);
+	template <typename T>
+	static T* get_array(GdArray array, int64_t index);
 protected:
 	Node *owner;
 protected:
@@ -78,5 +97,18 @@ public:
 	virtual void on_resume();
 	virtual ~SpxBaseMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor
 };
+
+template <typename T>
+T *SpxBaseMgr::get_array(GdArray array, int64_t index) {
+	return static_cast<T*>(_get_array(array, index, sizeof(T)));
+}
+template <typename T>
+void SpxBaseMgr::set_array(GdArray array, int64_t index, T value) {
+	auto ptr = get_array<T>(array, index);
+	if (ptr == nullptr) {
+		return;
+	}
+	*ptr = value;
+}
 
 #endif // SPX_BASE_MGR_H

--- a/modules/spx/spx_physic_mgr.cpp
+++ b/modules/spx/spx_physic_mgr.cpp
@@ -30,6 +30,7 @@
 
 #include "spx_physic_mgr.h"
 
+#include "gdextension_spx_ext.h"
 #include "scene/resources/world_2d.h"
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_3d.h"

--- a/platform/web/godot_js_spx_util.cpp
+++ b/platform/web/godot_js_spx_util.cpp
@@ -3,8 +3,9 @@
 
 #include "godot_js_spx_util.h"
 #include <string.h>
-#include <emscripten.h>
-
+#include <cstdlib>
+#include <cstdint>
+#include <emscripten/emscripten.h>
 
 static ObjectPool<GdVec2> vec2Pool(100);
 static ObjectPool<GdString> stringPool(100);
@@ -16,6 +17,64 @@ static ObjectPool<GdVec3> vec3Pool(100);
 static ObjectPool<GdVec4> vec4Pool(100);
 static ObjectPool<GdColor> colorPool(100);
 static ObjectPool<GdRect2> rect2Pool(100);
+static ObjectPool<GdArray> arrayPool(100);
+
+// Check if the machine is little-endian
+inline bool isLittleEndian() {
+    static const uint32_t test = 0x12345678;
+    return *reinterpret_cast<const uint8_t*>(&test) == 0x78;
+}
+
+// LittleEnd read functions
+uint64_t readUint64LE(const uint8_t* bytes) {
+    if (isLittleEndian()) {
+        return *reinterpret_cast<const uint64_t*>(bytes);
+    }
+    return (uint64_t)bytes[0] |
+           ((uint64_t)bytes[1] << 8) |
+           ((uint64_t)bytes[2] << 16) |
+           ((uint64_t)bytes[3] << 24) |
+           ((uint64_t)bytes[4] << 32) |
+           ((uint64_t)bytes[5] << 40) |
+           ((uint64_t)bytes[6] << 48) |
+           ((uint64_t)bytes[7] << 56);
+}
+
+uint32_t readUint32LE(const uint8_t* bytes) {
+    if (isLittleEndian()) {
+        return *reinterpret_cast<const uint32_t*>(bytes);
+    }
+    return (uint32_t)bytes[0] |
+           ((uint32_t)bytes[1] << 8) |
+           ((uint32_t)bytes[2] << 16) |
+           ((uint32_t)bytes[3] << 24);
+}
+
+void writeUint64LE(uint8_t* bytes, uint64_t value) {
+    if (isLittleEndian()) {
+        *reinterpret_cast<uint64_t*>(bytes) = value;
+        return;
+    }
+    bytes[0] = value & 0xFF;
+    bytes[1] = (value >> 8) & 0xFF;
+    bytes[2] = (value >> 16) & 0xFF;
+    bytes[3] = (value >> 24) & 0xFF;
+    bytes[4] = (value >> 32) & 0xFF;
+    bytes[5] = (value >> 40) & 0xFF;
+    bytes[6] = (value >> 48) & 0xFF;
+    bytes[7] = (value >> 56) & 0xFF;
+}
+
+void writeUint32LE(uint8_t* bytes, uint32_t value) {
+    if (isLittleEndian()) {
+        *reinterpret_cast<uint32_t*>(bytes) = value;
+        return;
+    }
+    bytes[0] = value & 0xFF;
+    bytes[1] = (value >> 8) & 0xFF;
+    bytes[2] = (value >> 16) & 0xFF;
+    bytes[3] = (value >> 24) & 0xFF;
+}
 
 extern "C" {
 
@@ -247,4 +306,257 @@ void gdspx_free_string(GdString* p_gdstr) {
     stringPool.release(p_gdstr);
 }
 
+
+
+// string functions
+EMSCRIPTEN_KEEPALIVE
+GdArray* gdspx_alloc_array() {
+    return arrayPool.acquire();
 }
+
+
+EMSCRIPTEN_KEEPALIVE
+void gdspx_free_array(GdArray* p_gdstr) {
+    if (p_gdstr == nullptr || *p_gdstr == nullptr) {
+        return;
+    }
+    
+    GdArrayInfo* info = *p_gdstr;
+    
+    if (info->data != nullptr) {
+        if (info->type == GD_ARRAY_TYPE_STRING) {
+            char** strings = (char**)info->data;
+            for (int64_t i = 0; i < info->size; i++) {
+                if (strings[i] != nullptr) {
+                    free(strings[i]);
+                }
+            }
+        }
+        free(info->data);
+    }
+    
+    free(info);
+    *p_gdstr = nullptr;
+    
+    arrayPool.release(p_gdstr);
+}
+
+GdArrayInfo* deserializeGdArray(uint8_t* bytes, int byteSize) {
+    if (byteSize < 8) {
+        return nullptr;
+    }
+    
+    GdArrayInfo* info = (GdArrayInfo*)malloc(sizeof(GdArrayInfo));
+    if (info == nullptr) {
+        return nullptr;
+    }
+    
+    // 8字节header: [size:4][type:4]
+    info->size = (int32_t)readUint32LE(bytes);
+    info->type = (int32_t)readUint32LE(bytes + 4);
+    
+    uint8_t* dataBytes = bytes + 8;
+    int dataSize = byteSize - 8;
+    
+    switch (info->type) {
+        case GD_ARRAY_TYPE_INT64:
+        case GD_ARRAY_TYPE_GDOBJ: {
+            int64_t* data = (int64_t*)malloc(info->size * sizeof(int64_t));
+            if (isLittleEndian()) {
+                memcpy(data, dataBytes, info->size * sizeof(int64_t));
+            } else {
+                for (int64_t i = 0; i < info->size; i++) {
+                    data[i] = (int64_t)readUint64LE(dataBytes + i * 8);
+                }
+            }
+            info->data = data;
+            break;
+        }
+        case GD_ARRAY_TYPE_FLOAT: {
+            float* data = (float*)malloc(info->size * sizeof(float));
+            if (isLittleEndian()) {
+                memcpy(data, dataBytes, info->size * sizeof(float));
+            } else {
+                for (int64_t i = 0; i < info->size; i++) {
+                    uint32_t bits = readUint32LE(dataBytes + i * 4);
+                    data[i] = *(float*)&bits;
+                }
+            }
+            info->data = data;
+            break;
+        }
+        case GD_ARRAY_TYPE_BOOL: {
+            bool* data = (bool*)malloc(info->size * sizeof(bool));
+            for (int64_t i = 0; i < info->size; i++) {
+                data[i] = dataBytes[i] != 0;
+            }
+            info->data = data;
+            break;
+        }
+        case GD_ARRAY_TYPE_BYTE: {
+            uint8_t* data = (uint8_t*)malloc(info->size);
+            memcpy(data, dataBytes, info->size);
+            info->data = data;
+            break;
+        }
+        case GD_ARRAY_TYPE_STRING: {
+            char** strings = (char**)malloc(info->size * sizeof(char*));
+            int offset = 0;
+            
+            for (int64_t i = 0; i < info->size; i++) {
+                if (offset + 4 > dataSize) {
+                    for (int64_t j = 0; j < i; j++) {
+                        free(strings[j]);
+                    }
+                    free(strings);
+                    free(info);
+                    return nullptr;
+                }
+                
+                uint32_t strLen = readUint32LE(dataBytes + offset);
+                offset += 4;
+                
+                if (offset + strLen > dataSize) {
+                    for (int64_t j = 0; j < i; j++) {
+                        free(strings[j]);
+                    }
+                    free(strings);
+                    free(info);
+                    return nullptr;
+                }
+                
+                // alloc and copy strings
+                strings[i] = (char*)malloc(strLen + 1);
+                memcpy(strings[i], dataBytes + offset, strLen);
+                strings[i][strLen] = '\0';
+                offset += strLen;
+            }
+            info->data = strings;
+            break;
+        }
+        default:
+            free(info);
+            return nullptr;
+    }
+    
+    return info;
+}
+
+uint8_t* serializeGdArray(GdArrayInfo* info, int* outSize) {
+    if (info == nullptr) {
+        print_line("serializeGdArray null");
+        *outSize = 0;
+        return nullptr;
+    }
+    
+    int dataSize = 0;
+    
+    switch (info->type) {
+        case GD_ARRAY_TYPE_INT64:
+        case GD_ARRAY_TYPE_GDOBJ:
+            dataSize = info->size * 8;
+            break;
+        case GD_ARRAY_TYPE_FLOAT:
+            dataSize = info->size * 4;
+            break;
+        case GD_ARRAY_TYPE_BOOL:
+        case GD_ARRAY_TYPE_BYTE:
+            dataSize = info->size;
+            break;
+        case GD_ARRAY_TYPE_STRING: {
+            char** strings = (char**)info->data;
+            dataSize = 0;
+            for (int64_t i = 0; i < info->size; i++) {
+                dataSize += 4 + strlen(strings[i]);
+            }
+            break;
+        }
+        default:
+            *outSize = 0;
+            print_line("error: Unknown array type", info->type);
+            return nullptr;
+    }
+    
+    int totalSize = 8 + dataSize;
+    uint8_t* result = (uint8_t*)malloc(totalSize);
+    if (result == nullptr) {
+        *outSize = 0;
+        return nullptr;
+    }
+    
+    // 8字节header: [size:4][type:4]
+    writeUint32LE(result, (uint32_t)info->size);
+    writeUint32LE(result + 4, (uint32_t)info->type);
+    
+    uint8_t* dataPtr = result + 8;
+    switch (info->type) {
+        case GD_ARRAY_TYPE_INT64:
+        case GD_ARRAY_TYPE_GDOBJ: {
+            int64_t* data = (int64_t*)info->data;
+            if (isLittleEndian()) {
+                memcpy(dataPtr, data, info->size * sizeof(int64_t));
+            } else {
+                for (int64_t i = 0; i < info->size; i++) {
+                    writeUint64LE(dataPtr + i * 8, (uint64_t)data[i]);
+                }
+            }
+            break;
+        }
+        case GD_ARRAY_TYPE_FLOAT: {
+            float* data = (float*)info->data;
+            if (isLittleEndian()) {
+                memcpy(dataPtr, data, info->size * sizeof(float));
+            } else {
+                for (int64_t i = 0; i < info->size; i++) {
+                    uint32_t bits = *(uint32_t*)&data[i];
+                    writeUint32LE(dataPtr + i * 4, bits);
+                }
+            }
+            break;
+        }
+        case GD_ARRAY_TYPE_BOOL: {
+            bool* data = (bool*)info->data;
+            for (int64_t i = 0; i < info->size; i++) {
+                dataPtr[i] = data[i] ? 1 : 0;
+            }
+            break;
+        }
+        case GD_ARRAY_TYPE_BYTE: {
+            memcpy(dataPtr, info->data, info->size);
+            break;
+        }
+        case GD_ARRAY_TYPE_STRING: {
+            char** strings = (char**)info->data;
+            int offset = 0;
+            for (int64_t i = 0; i < info->size; i++) {
+                uint32_t strLen = strlen(strings[i]);
+                writeUint32LE(dataPtr + offset, strLen);
+                offset += 4;
+                memcpy(dataPtr + offset, strings[i], strLen);
+                offset += strLen;
+            }
+            break;
+        }
+    }
+    
+    *outSize = totalSize;
+    return result;
+}
+
+EMSCRIPTEN_KEEPALIVE
+uint8_t* gdspx_to_js_array(GdArray* p_gdstr, int* outSize) {
+    if (p_gdstr == nullptr || *p_gdstr == nullptr) {
+        return nullptr;
+    }
+    GdArrayInfo* info = *p_gdstr;
+    return serializeGdArray(info,outSize);
+}
+EMSCRIPTEN_KEEPALIVE
+GdArray* gdspx_to_gd_array(uint8_t* bytes, int byteSize) {
+    GdArray* p_gdstr = gdspx_alloc_array();
+    GdArrayInfo* info = deserializeGdArray(bytes, byteSize);
+    *p_gdstr = info;
+    return p_gdstr;
+}
+
+}// extern "C"


### PR DESCRIPTION
Go JS C++ automatic wrapper code generation support for passing Array array types: Currently supported types include: 
- []Int64  = 1
- []Float  = 2
- []Bool   = 3
- []String = 4
- []Byte   = 5
- []GdObj  = 6

eg: 
```cpp
	GdArray check_collision_rect(GdVec2 pos, GdVec2 size);
	GdArray check_collision_circle(GdVec2 pos, GdFloat radius);
	
	GdArray SpxPhysicMgr::check_collision_rect(GdVec2 pos, GdVec2 size ){
	        print_line("check_collision_rect", pos, size, "should be -3,65535");
	        auto ary = create_array(GD_ARRAY_TYPE_GDOBJ,2);
	        set_array(ary, 0, (GdObj)-3);
	        set_array(ary, 1,  (GdObj)65535);
	        return ary;
         }
```

```go
func testArray() {
	va1 := physicMgr.CheckCollisionRect(mathf.NewVec2(-1, 2), mathf.NewVec2(2, 4))
	fmt.Printf("testArray1==> %v \n", va1)
	va2 := physicMgr.CheckCollisionCircle(mathf.NewVec2(-1, 6), 1)
	fmt.Printf("testArray2==> %v \n", va2)
}
```