### PR TITLE
Feat: add debug draw util function

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -187,6 +187,12 @@ static void gdextension_spx_ext_set_pen_size_to(GdObj obj,GdFloat size) {
 static void gdextension_spx_ext_set_pen_stamp_texture(GdObj obj,GdString texture_path) {
 	 extMgr->set_pen_stamp_texture(obj, texture_path);
 }
+static void gdextension_spx_ext_debug_draw_circle(GdVec2 pos,GdFloat radius,GdColor color) {
+	 extMgr->debug_draw_circle(pos, radius, color);
+}
+static void gdextension_spx_ext_debug_draw_rect(GdVec2 pos,GdVec2 size,GdColor color) {
+	 extMgr->debug_draw_rect(pos, size, color);
+}
 static void gdextension_spx_input_get_mouse_pos(GdVec2* ret_val) {
 	*ret_val = inputMgr->get_mouse_pos();
 }
@@ -811,6 +817,8 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_change_pen_size_by);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_set_pen_size_to);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ext_set_pen_stamp_texture);
+	REGISTER_SPX_INTERFACE_FUNC(spx_ext_debug_draw_circle);
+	REGISTER_SPX_INTERFACE_FUNC(spx_ext_debug_draw_rect);
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_get_mouse_pos);
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_get_key);
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_get_mouse_state);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -259,6 +259,8 @@ typedef void (*GDExtensionSpxExtSetPenTo)(GdObj obj, GdInt property, GdFloat val
 typedef void (*GDExtensionSpxExtChangePenSizeBy)(GdObj obj, GdFloat amount);
 typedef void (*GDExtensionSpxExtSetPenSizeTo)(GdObj obj, GdFloat size);
 typedef void (*GDExtensionSpxExtSetPenStampTexture)(GdObj obj, GdString texture_path);
+typedef void (*GDExtensionSpxExtDebugDrawCircle)(GdVec2 pos, GdFloat radius, GdColor color);
+typedef void (*GDExtensionSpxExtDebugDrawRect)(GdVec2 pos, GdVec2 size, GdColor color);
 // SpxInput
 typedef void (*GDExtensionSpxInputGetMousePos)(GdVec2* ret_value);
 typedef void (*GDExtensionSpxInputGetKey)(GdInt key, GdBool* ret_value);

--- a/modules/spx/spx_ext_mgr.h
+++ b/modules/spx/spx_ext_mgr.h
@@ -36,6 +36,20 @@
 #include "spx_base_mgr.h"
 
 class SpxPen;
+
+struct DebugShape {
+	enum Type {
+		CIRCLE,
+		RECT
+	};
+	Type type;
+	GdVec2 position;
+	GdVec2 size;
+	GdFloat radius;
+	GdColor color;
+	Node2D *node;
+};
+
 class SpxExtMgr : SpxBaseMgr {
 	SPXCLASS(SpxExtMgr, SpxBaseMgr)
 public:
@@ -44,10 +58,14 @@ public:
 private:
 	RBMap<GdObj, SpxPen *> id_pens;
 	Node *pen_root;
+	
+	Vector<DebugShape> debug_shapes;
+	Node2D *debug_root;
 
 	static Mutex lock;
 private:
 	SpxPen *_get_pen(GdObj id);
+	void _clear_debug_shapes();
 
 public:
 	void on_awake() override;
@@ -80,6 +98,10 @@ public:
 	void change_pen_size_by(GdObj obj, GdFloat amount);
 	void set_pen_size_to(GdObj obj, GdFloat size);
 	void set_pen_stamp_texture(GdObj obj, GdString texture_path);
+
+	// debug
+	void debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color);
+	void debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color);
 };
 
 #endif // SPX_EXT_MGR_H

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -239,6 +239,14 @@ void gdspx_ext_set_pen_stamp_texture(GdObj* obj,GdString* texture_path) {
 	 extMgr->set_pen_stamp_texture(*obj, *texture_path);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_ext_debug_draw_circle(GdVec2* pos,GdFloat* radius,GdColor* color) {
+	 extMgr->debug_draw_circle(*pos, *radius, *color);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_ext_debug_draw_rect(GdVec2* pos,GdVec2* size,GdColor* color) {
+	 extMgr->debug_draw_rect(*pos, *size, *color);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_input_get_mouse_pos(GdVec2* ret_val) {
 	*ret_val = inputMgr->get_mouse_pos();
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -379,6 +379,30 @@ gdspx_ext_set_pen_stamp_texture(obj,texture_path) {
 	FreeGdString(_arg1); 
 
 }
+gdspx_ext_debug_draw_circle(pos,radius,color) {
+	var _gdFuncPtr = Module._gdspx_ext_debug_draw_circle; 
+	
+	var _arg0 = ToGdVec2(pos);
+	var _arg1 = ToGdFloat(radius);
+	var _arg2 = ToGdColor(color);
+	_gdFuncPtr(_arg0, _arg1, _arg2);
+	FreeGdVec2(_arg0); 
+	FreeGdFloat(_arg1); 
+	FreeGdColor(_arg2); 
+
+}
+gdspx_ext_debug_draw_rect(pos,size,color) {
+	var _gdFuncPtr = Module._gdspx_ext_debug_draw_rect; 
+	
+	var _arg0 = ToGdVec2(pos);
+	var _arg1 = ToGdVec2(size);
+	var _arg2 = ToGdColor(color);
+	_gdFuncPtr(_arg0, _arg1, _arg2);
+	FreeGdVec2(_arg0); 
+	FreeGdVec2(_arg1); 
+	FreeGdColor(_arg2); 
+
+}
 gdspx_input_get_mouse_pos() {
 	var _gdFuncPtr = Module._gdspx_input_get_mouse_pos; 
 	var _retValue = AllocGdVec2();


### PR DESCRIPTION
These functions draw the shapes that persist only for **`1`** frame. To use them, you need to call the drawing function every frame to render the desired shapes
```cpp
	void debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color);
	void debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color);
```