### PR TITLE
Fix anim error of JavaScript error: memory access out of bounds

### DIFF
--- a/modules/spx/spx_sprite.h
+++ b/modules/spx/spx_sprite.h
@@ -163,7 +163,7 @@ private:
 	int current_svg_scale = 1; // Current SVG animation scale
 	String current_svg_path; // Name of the current SVG animation (image)
 	String current_svg_anim_key; // Name of the current SVG animation
-	String current_anim_name; // Name of the current animation
+	String current_anim_name = ""; // Name of the current animation
 	
 
 	void update_anim_scale();


### PR DESCRIPTION
test project:  https://github.com/realdream-ai/spx_demos/17_PlantsVsZombie
Fix 
```cs
panic: JavaScript error: memory access out of bounds
go.wasm.exec.js:22 
go.wasm.exec.js:22 goroutine 7 [running]:
go.wasm.exec.js:22 syscall/js.Value.Invoke({{}, 0x7ff8000400000134, 0x6a170b8}, {0x69d5c70, 0x1, 0x1})
go.wasm.exec.js:22 	/Users/tjp/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.darwin-arm64/src/syscall/js/js.go:473 +0x18
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/internal/wrap.(*spriteMgr).GetCurrentAnimName(0x18a8ca0, 0x2e)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/internal/wrap/manager_wrapper_web.gen.go:1072 +0x6
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/pkg/engine.(*Sprite).GetCurrentAnimName(...)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/pkg/engine/sprite.gen.go:108
go.wasm.exec.js:22 github.com/goplus/spx/v2.(*SpriteImpl).syncOnAnimationFinished(0x574d508)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/gdspx.go:145 +0x12
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/pkg/engine.(*Event0).Trigger(0x449e460)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/pkg/engine/event.go:68 +0x2c
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/pkg/engine.(*Sprite).V_OnAnimationFinished(...)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/pkg/engine/sprite.go:79
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/internal/engine.onSpriteAnimationFinished(0x2e)
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/internal/engine/callback.go:200 +0x6
go.wasm.exec.js:22 github.com/goplus/spx/v2/pkg/gdspx/internal/webffi.gdspxOnSpriteAnimationFinished({{}, 0x7ff8000100000005, 0x81835c8}, {0x50046a0, 0x1, 0x1})
go.wasm.exec.js:22 	/Users/tjp/projects/spx/pkg/gdspx/internal/webffi/callbacks.gen.go:133 +0xa
go.wasm.exec.js:22 syscall/js.handleEvent()
go.wasm.exec.js:22 	/Users/tjp/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.darwin-arm64/src/syscall/js/func.go:117 +0x28
go.wasm.exec.js:101 exit code: 2
exit @ go.wasm.exec.js:101
```