### PR TITLE
Clear SpxLayerSorter to avoid dangling pointers: signal: segmentation fault

### DIFF
--- a/modules/spx/spx_scene_mgr.cpp
+++ b/modules/spx/spx_scene_mgr.cpp
@@ -65,7 +65,12 @@ void SpxSceneMgr::on_awake() {
 }
 
 void SpxSceneMgr::on_destroy() {
-	clear_pure_sprites();
+	// Clear pure sprites without recreating the root node (we're destroying)
+	id_pure_sprites.clear();
+	SpxLayerSorter::instance().reset();
+	if (pure_sprite_root) {
+		pure_sprite_root->queue_free();
+	}
 	pure_sprite_root = nullptr;
 	SpxBaseMgr::on_destroy();
 }
@@ -73,6 +78,8 @@ void SpxSceneMgr::on_destroy() {
 
 void SpxSceneMgr::clear_pure_sprites(){
 	id_pure_sprites.clear();
+	// Clear SpxLayerSorter to avoid dangling pointers
+	SpxLayerSorter::instance().reset();
 	if (pure_sprite_root) {
 		pure_sprite_root->queue_free();
 		pure_sprite_root = memnew(Node2D);
@@ -93,6 +100,10 @@ void SpxSceneMgr::destroy_pure_sprite(GdObj id) {
 		auto sprite = id_pure_sprites[id];
 		id_pure_sprites.erase(id);
 
+		// Clear SpxLayerSorter to avoid dangling pointers
+		// Note: This is conservative but safe. Could be optimized later with per-id removal.
+		SpxLayerSorter::instance().reset();
+		
 		// Cast to Node2D to remove from scene tree
 		Node2D* node = dynamic_cast<Node2D*>(sprite);
 		if (node && node->is_inside_tree()) {


### PR DESCRIPTION
Fix  https://github.com/goplus/spx/issues/961
test project: [test_crash.zip](https://github.com/user-attachments/files/22994890/test_crash.zip)

```cs
ztjp@tjp ~/projects/spx/test/CI $ spx run 
Running command: go mod tidy
[DEBUG] handleBuildPhase: command=run, tags=0x14000026270
[DEBUG] Checking BuildDll conditions
[DEBUG] Executing BuildDll
2025/10/20 11:01:13 genGo tagStr: -tags=simulation
Running command: xgo go -tags=simulation
GenGo . ...
Running command: go mod tidy
build dll arch= amd64 -tags=simulation
Running command: go build -tags=simulation -o /Users/tjp/projects/spx/test/CI/project/lib/gdspx-darwin-amd64.dylib -buildmode=c-shared
build dll arch= arm64 -tags=simulation
Running command: go build -tags=simulation -o /Users/tjp/projects/spx/test/CI/project/lib/gdspx-darwin-arm64.dylib -buildmode=c-shared
Running command: /Users/tjp/go/bin/gdspxrt2.1.20 --path /Users/tjp/projects/spx/test/CI/.temp --gdextpath /Users/tjp/projects/spx/test/CI/.temp/runtime.gdextension
In directory: /Users/tjp/projects/spx/test/CI/.temp
Godot Engine v4.4.1.stable.custom_build.c01d16a2c (2025-10-20 02:24:40 UTC) - https://godotengine.org
Metal 3.2 - Forward+ - Using Device #0: Apple - Apple M4 (Apple9)

onStart
onStart done
===>SpxCIRunSucc
2025/10/20 11:01:14 Command /Users/tjp/go/bin/gdspxrt2.1.20 failed: signal: segmentation fault
```
