### PR TITLE
Move coord convert to go invert Y

### DIFF
--- a/modules/spx/spx_debug_mgr.cpp
+++ b/modules/spx/spx_debug_mgr.cpp
@@ -104,7 +104,6 @@ void SpxDebugMgr::debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color) {
 		return;
 	}
 
-	pos.y = -pos.y;
 	Line2D* circle = memnew(Line2D);
 	circle->set_default_color(color);
 	circle->set_width(2.0f);
@@ -137,8 +136,7 @@ void SpxDebugMgr::debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color) {
 	Line2D* rect = memnew(Line2D);
 	rect->set_default_color(color);
 	rect->set_width(2.0f);
-	
-	pos.y = -pos.y;
+
 	size = size * 0.5;
 	PackedVector2Array points;
 	points.append(Vector2(-size.x, -size.y));
@@ -164,10 +162,6 @@ void SpxDebugMgr::debug_draw_line(GdVec2 from, GdVec2 to, GdColor color) {
 	if (!debug_root) {
 		return;
 	}
-
-	// 翻转Y轴坐标
-	from.y = -from.y;
-	to.y = -to.y;
 
 	Line2D* line = memnew(Line2D);
 	line->set_default_color(color);

--- a/modules/spx/spx_draw_tiles.cpp
+++ b/modules/spx/spx_draw_tiles.cpp
@@ -275,12 +275,10 @@ void SpxDrawTiles::place_tile_spx(GdVec2 pos, GdString texture_path, GdInt index
 }
 
 void SpxDrawTiles::erase_tile_spx(GdVec2 pos, GdInt layer_index) {
-    auto flipped_pos = flip_y(pos);
-
     auto erase_at_layer = [&](TileMapLayer* layer) {
         if (!layer) return;
 
-        Vector2 local_pos = layer->to_local(flipped_pos);
+        Vector2 local_pos = layer->to_local(pos);
         Vector2i coords = layer->local_to_map(local_pos);
         layer->erase_cell(coords);
     };
@@ -304,7 +302,7 @@ GdString SpxDrawTiles::get_tile_spx(GdVec2 pos, GdInt layer_index) {
 
     if(index_layer_map.has(layer_index)){
         auto layer = index_layer_map[layer_index];
-        Vector2 local_pos = layer->to_local(flip_y(pos));
+        Vector2 local_pos = layer->to_local(pos);
         Vector2i coords = layer->local_to_map(local_pos);
         return SpxReturnStr(_get_tile_texture_path(layer, coords));
     }
@@ -332,7 +330,7 @@ void SpxDrawTiles::set_tile_texture_spx(GdString texture_path, const Vector<Vect
 }
 
 void SpxDrawTiles::erase_tile_spx(GdVec2 pos) {
-    place_or_erase_tile(flip_y(pos), true);
+    place_or_erase_tile(pos, true);
 }
 
 void SpxDrawTiles::_place_tiles_bulk_spx(GdArray positions) {
@@ -353,7 +351,7 @@ void SpxDrawTiles::_place_tiles_bulk_spx(GdArray positions) {
         auto y = *(SpxBaseMgr::get_array<float>(positions, i + 1));
 
         Vector2 pos = {x, y};
-        Vector2 local_pos = layer->to_local(flip_y(pos));
+        Vector2 local_pos = layer->to_local(pos);
         Vector2i coords = layer->local_to_map(local_pos);
 
         layer->set_cell(coords, source_id, default_atlas_coord, 0);
@@ -361,7 +359,7 @@ void SpxDrawTiles::_place_tiles_bulk_spx(GdArray positions) {
 }
 
 void SpxDrawTiles::_place_tile_spx(GdVec2 pos) {
-    place_or_erase_tile(flip_y(pos), false);
+    place_or_erase_tile(pos, false);
 }
 
 void SpxDrawTiles::set_layer_index(int index) {
@@ -376,7 +374,7 @@ void SpxDrawTiles::set_layer_offset_spx(int layer_index, Vector2 offset) {
         return;
     }
 
-    layer->set_position(flip_y(offset));
+    layer->set_position(offset);
 }
 
 Vector2 SpxDrawTiles::get_layer_offset_spx(int layer_index) {
@@ -385,8 +383,7 @@ Vector2 SpxDrawTiles::get_layer_offset_spx(int layer_index) {
         return Vector2();
     }
 
-    auto pos = layer->get_position();
-    return flip_y(pos);
+    return layer->get_position();
 }
 
 void SpxDrawTiles::set_texture(Ref<Texture2D> texture, bool with_collision) {

--- a/modules/spx/spx_draw_tiles.h
+++ b/modules/spx/spx_draw_tiles.h
@@ -238,7 +238,6 @@ private:
 
     void _place_tiles_bulk_spx(GdArray positions);
     void _place_tile_spx(GdVec2 pos);
-    _FORCE_INLINE_ Vector2 flip_y(const Vector2 &pos) { return pos * Vector2(1, -1); }
 
     void _destroy_layers();
     void _clear_cache();

--- a/modules/spx/spx_input_mgr.cpp
+++ b/modules/spx/spx_input_mgr.cpp
@@ -50,8 +50,7 @@ void SpxInputMgr::on_reset(int reset_code) {
 
 // input
 GdVec2 SpxInputMgr::get_global_mouse_pos() {
-	auto mouse_pos = cameraMgr->get_global_mouse_position();
-	return GdVec2(mouse_pos.x, -mouse_pos.y);
+	return cameraMgr->get_global_mouse_position();
 }
 
 GdBool SpxInputMgr::get_mouse_state(GdInt mouse_id) {

--- a/modules/spx/spx_path_finder.cpp
+++ b/modules/spx/spx_path_finder.cpp
@@ -131,14 +131,14 @@ void SpxPathFinder::set_sprite_obstacle(GdObj obj, bool enabled) {
 }
 
 GdArray SpxPathFinder::find_path_spx(GdVec2 p_from, GdVec2 p_to) {
-    auto path_points = find_path(p_from * Vector2(1, -1), p_to * Vector2(1, -1));
+    auto path_points = find_path(p_from, p_to);
     auto count = path_points.size();
 	GdArray result = SpxBaseMgr::create_array(GD_ARRAY_TYPE_FLOAT, count * 2);
 
 	for(auto i = 0; i < count; i ++){
         auto idx = i * 2;
 		SpxBaseMgr::set_array(result, idx, path_points[i].x);
-		SpxBaseMgr::set_array(result, idx + 1, -path_points[i].y);
+		SpxBaseMgr::set_array(result, idx + 1, path_points[i].y);
 	}
 
 	return result;

--- a/modules/spx/spx_physic_mgr.cpp
+++ b/modules/spx/spx_physic_mgr.cpp
@@ -108,10 +108,6 @@ SpxRaycastInfo SpxPhysicMgr::_raycast(GdVec2 from, GdVec2 to,GdArray ignore_spri
 	info.normal = GdVec2{0, 0};
 	info.sprite_gid = 0;
 
-	// invert y
-	GdVec2 current_from = GdVec2{from.x, -from.y};
-	GdVec2 target_to = GdVec2{to.x, -to.y};
-
 	HashSet<RID> ignore_set;
 	if(ignore_sprites && ignore_sprites->size > 0){
 		GdObj* sprite_data = (SpxBaseMgr::get_array<GdObj>(ignore_sprites, 0));
@@ -129,8 +125,8 @@ SpxRaycastInfo SpxPhysicMgr::_raycast(GdVec2 from, GdVec2 to,GdArray ignore_spri
 	}
 	PhysicsDirectSpaceState2D::RayResult result;
 	PhysicsDirectSpaceState2D::RayParameters params;
-	params.from = current_from;
-	params.to = target_to;
+	params.from = from;
+	params.to = to;
 	params.collision_mask = (uint32_t)collision_mask;
 	params.collide_with_areas = collide_with_areas;
 	params.collide_with_bodies = collide_with_bodies;
@@ -149,8 +145,8 @@ SpxRaycastInfo SpxPhysicMgr::_raycast(GdVec2 from, GdVec2 to,GdArray ignore_spri
 	SpxSprite *collider = dynamic_cast<SpxSprite *>(result.collider);
 	GdObj current_gid = collider ? collider->get_gid() : 0;
 	info.collide = true;
-	info.position = GdVec2{result.position.x, -result.position.y};
-	info.normal = GdVec2{result.normal.x, -result.normal.y};
+	info.position = result.position;
+	info.normal = result.normal;
 	info.sprite_gid = current_gid;
 	return info;
 }
@@ -168,9 +164,6 @@ GdObj SpxPhysicMgr::raycast(GdVec2 from, GdVec2 to, GdInt collision_mask) {
 
 	PhysicsDirectSpaceState2D::RayResult result;
 	PhysicsDirectSpaceState2D::RayParameters params;
-	// flip y axis
-	from = GdVec2{ from.x, -from.y };
-	to = GdVec2{ to.x, -to.y };
 	params.from = from;
 	params.to = to;
 	params.collision_mask = (uint32_t)collision_mask;
@@ -189,10 +182,6 @@ GdBool SpxPhysicMgr::check_collision(GdVec2 from, GdVec2 to, GdInt collision_mas
 	PhysicsDirectSpaceState2D *space_state = node->get_world_2d()->get_direct_space_state();
 	PhysicsDirectSpaceState2D::RayResult result;
 	PhysicsDirectSpaceState2D::RayParameters params;
-
-	// flip y axis
-	from = GdVec2{ from.x, -from.y };
-	to = GdVec2{ to.x, -to.y };
 	params.from = from;
 	params.to = to;
 	params.collision_mask = (uint32_t)collision_mask;
@@ -300,8 +289,7 @@ GdArray SpxPhysicMgr::_check_collision(RID shape, GdVec2 pos, GdInt collision_ma
 		return create_array(GD_ARRAY_TYPE_GDOBJ, 0);
 	}
 
-	GdVec2 flipped_pos = GdVec2{ pos.x, -pos.y };
-	Transform2D query_transform(0, flipped_pos);
+	Transform2D query_transform(0, pos);
 
 	PhysicsDirectSpaceState2D::ShapeParameters params;
 	params.shape_rid = shape;

--- a/modules/spx/spx_scene_mgr.cpp
+++ b/modules/spx/spx_scene_mgr.cpp
@@ -231,11 +231,11 @@ GdObj SpxSceneMgr::create_render_sprite(GdString texture_path, GdVec2 pos, GdFlo
 	}
 
 	SpxRenderSprite* sprite = memnew(SpxRenderSprite);
-	sprite->set_pivot(GdVec2(pivot.x, -pivot.y));
+	sprite->set_pivot(pivot);
 	auto path_str = SpxStr(texture_path);
 	Ref<Texture2D> texture = resMgr->load_texture(path_str, true);
 	sprite->set_texture(texture);
-	sprite->set_position(Vector2(pos.x, -pos.y));
+	sprite->set_position(pos);
 	sprite->set_rotation_degrees(degree);
 	sprite->set_scale(Vector2(scale.x, scale.y));
 	sprite->set_name(path_str.get_file());
@@ -262,7 +262,7 @@ GdObj SpxSceneMgr::create_static_sprite(GdString texture_path, GdVec2 pos,GdFloa
 	auto path_str = SpxStr(texture_path);
 	// Create StaticBody2D
 	SpxStaticSprite* static_body = memnew(SpxStaticSprite);
-	static_body->set_position(Vector2(pos.x, -pos.y));
+	static_body->set_position(pos);
 	static_body->set_rotation_degrees(degree);
 	static_body->set_name(path_str.get_file());
 
@@ -271,15 +271,15 @@ GdObj SpxSceneMgr::create_static_sprite(GdString texture_path, GdVec2 pos,GdFloa
 	Ref<Texture2D> texture = resMgr->load_texture(path_str, true);
 	sprite->set_texture(texture);
 	sprite->set_z_index(zindex);
-	static_body->add_child(sprite);   
-	sprite->set_position(Vector2(pivot.x, -pivot.y));
+	static_body->add_child(sprite);
+	sprite->set_position(pivot);
 
 	// Create collision shape (default: rectangle matching texture size)
 	CollisionShape2D* collision_shape = memnew(CollisionShape2D);
 
 	static_body->collider2d = collision_shape;
 	static_body->add_child(collision_shape);
-	collision_shape->set_position(Vector2(collider_pivot.x, -collider_pivot.y));
+	collision_shape->set_position(collider_pivot);
 	auto data_len =  collider_params == nullptr ? 0 : collider_params->size;
 	switch (type)
 	{

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -196,7 +196,7 @@ void SpxSpriteMgr::set_child_position(GdObj obj, GdString path, GdVec2 pos) {
 	check_and_get_sprite_v()
 	auto child = (Node2D *)sprite->get_node(SpxStr(path));
 	if (child != nullptr) {
-		child->set_position(GdVec2{ pos.x, -pos.y });
+		child->set_position(pos);
 	}
 }
 
@@ -204,8 +204,7 @@ GdVec2 SpxSpriteMgr::get_child_position(GdObj obj, GdString path) {
 	check_and_get_sprite_r(GdVec2())
 	auto child = (Node2D *)sprite->get_node(SpxStr(path));
 	if (child != nullptr) {
-		auto pos = child->get_position();
-		return GdVec2{ pos.x, -pos.y };
+		return child->get_position();
 	}
 	return GdVec2();
 }
@@ -252,7 +251,6 @@ GdBool SpxSpriteMgr::check_collision(GdObj obj, GdObj target, GdBool is_src_trig
 
 GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger) {
 	check_and_get_sprite_r(false)
-	point.y = - point.y;
 	return sprite->check_collision_with_point(point, is_trigger);
 }
 
@@ -270,7 +268,7 @@ GdInt SpxSpriteMgr::_create_sprite(GdString path, GdVec2 pos, GdBool is_backdrop
 	SpxSprite *sprite = nullptr;
 	if (path_str == "") {
 		sprite = memnew(SpxSprite);
-		sprite->set_position(GdVec2(pos.x, -pos.y));
+		sprite->set_position(pos);
 		AnimatedSprite2D *animated_sprite = memnew(AnimatedSprite2D);
 		sprite->add_child(animated_sprite);
 		Area2D *area = memnew(Area2D);
@@ -345,8 +343,7 @@ GdBool SpxSpriteMgr::is_sprite_alive(GdObj obj) {
 
 void SpxSpriteMgr::set_position(GdObj obj, GdVec2 pos) {
 	check_and_get_sprite_v()
-	// flip y axis
-	sprite->set_position(GdVec2(pos.x, -pos.y));
+	sprite->set_position(pos);
 }
 
 void SpxSpriteMgr::set_rotation(GdObj obj, GdFloat rot) {
@@ -361,9 +358,7 @@ void SpxSpriteMgr::set_scale(GdObj obj, GdVec2 scale) {
 
 GdVec2 SpxSpriteMgr::get_position(GdObj obj) {
 	check_and_get_sprite_r(GdVec2())
-	auto pos = sprite->get_position();
-	// flip y axis
-	return GdVec2{ pos.x, -pos.y };
+	return sprite->get_position();
 }
 
 GdFloat SpxSpriteMgr::get_rotation(GdObj obj) {
@@ -596,15 +591,12 @@ GdString SpxSpriteMgr::get_current_anim_name(GdObj obj) {
 
 void SpxSpriteMgr::set_velocity(GdObj obj, GdVec2 velocity) {
 	check_and_get_sprite_v()
-	// flip y axis
-	sprite->set_velocity(GdVec2(velocity.x, -velocity.y));
+	sprite->set_velocity(velocity);
 }
 
 GdVec2 SpxSpriteMgr::get_velocity(GdObj obj) {
 	check_and_get_sprite_r(GdVec2())
-	auto val = sprite->get_velocity();
-	// flip y axis
-	return GdVec2{ val.x, -val.y };
+	return sprite->get_velocity();
 }
 
 GdBool SpxSpriteMgr::is_on_floor(GdObj obj) {
@@ -1092,11 +1084,9 @@ void SpxSpriteMgr::_check_pixel_collision_events() {
 
 void SpxSpriteMgr::set_pivot(GdObj obj, GdVec2 pivot){
 	check_and_get_sprite_v()
-	pivot.y = - pivot.y;
 	sprite->set_pivot(pivot);
 }
 GdVec2 SpxSpriteMgr::get_pivot(GdObj obj){
 	check_and_get_sprite_r(GdVec2())
-	auto pivot= sprite->get_pivot();
-	return GdVec2(pivot.x,-pivot.y);
+	return sprite->get_pivot();
 }


### PR DESCRIPTION
related pr: https://github.com/goplus/spx/pull/973


The goal is to migrate the coordinate transformation from C++ to Go and unify the implementation approach （Invert Y）

### **1. spx_sprite_mgr.cpp**: 9 conversions  
   - Position, velocity, and anchor point `set`/`get` methods  
   - Collision detection points  

### **2. spx_physic_mgr.cpp**: 6 conversions  
   - Raycast input/output  
   - Shape queries  

### **3. spx_scene_mgr.cpp**: 5 conversions  
   - Position/pivot setup when rendering sprites and creating static sprites  

### **4. spx_draw_tiles.cpp/h**: 8 conversions  
   - All tilemap coordinate operations go through the `flip_y()` function  

### **5. spx_debug_mgr.cpp**: 4 conversions  
   - Debug drawing functions (circles, rectangles, lines)  

### **6. spx_input_mgr.cpp**: 1 conversion  
   - Mouse position retrieval  

### **7. spx_path_finder.cpp**: 2 conversions  
   - Pathfinding input/output  

### **Conversion Patterns**  

- **Input parameter conversion**: `pos.y = -pos.y` or `GdVec2(pos.x, -pos.y)`  
- **Return value conversion**: `return GdVec2(val.x, -val.y)`  
- **Helper function**: `flip_y()` (used in `spx_draw_tiles`)  
