### PR TITLE
Refactor(spx): fix inheritance and eliminate macro duplication

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -35,6 +35,7 @@
 #include "gdextension_interface.h"
 #include "scene/main/window.h"
 #include "spx_engine.h"
+#include "spx_mgr_access.h"
 #include "spx_audio_mgr.h"
 #include "spx_camera_mgr.h"
 #include "spx_debug_mgr.h"
@@ -50,20 +51,6 @@
 #include "spx_tilemap_mgr.h"
 #include "spx_ui_mgr.h"
 
-#define audioMgr SpxEngine::get_singleton()->get_audio()
-#define cameraMgr SpxEngine::get_singleton()->get_camera()
-#define debugMgr SpxEngine::get_singleton()->get_debug()
-#define extMgr SpxEngine::get_singleton()->get_ext()
-#define inputMgr SpxEngine::get_singleton()->get_input()
-#define navigationMgr SpxEngine::get_singleton()->get_navigation()
-#define penMgr SpxEngine::get_singleton()->get_pen()
-#define physicMgr SpxEngine::get_singleton()->get_physic()
-#define platformMgr SpxEngine::get_singleton()->get_platform()
-#define resMgr SpxEngine::get_singleton()->get_res()
-#define sceneMgr SpxEngine::get_singleton()->get_scene()
-#define spriteMgr SpxEngine::get_singleton()->get_sprite()
-#define tilemapMgr SpxEngine::get_singleton()->get_tilemap()
-#define uiMgr SpxEngine::get_singleton()->get_ui()
 
 #define REGISTER_SPX_INTERFACE_FUNC(m_name) GDExtension::register_interface_function( #m_name, (GDExtensionInterfaceFunctionPtr)&gdextension_##m_name)
 static void gdextension_spx_global_register_callbacks(GDExtensionSpxCallbackInfoPtr callback_ptr) {

--- a/modules/spx/spx_base_mgr.h
+++ b/modules/spx/spx_base_mgr.h
@@ -35,6 +35,7 @@
 #include "scene/2d/node_2d.h"
 #include "svg_mgr.h"
 #include "spx_utils.h"
+#include "spx_mgr_access.h"
 
 #define SPXCLASS(m_class, m_inherits) \
 public:                               \
@@ -42,16 +43,6 @@ public:                               \
 
 #define SpxStr(str) (String::utf8((const char *)str))
 #define SpxReturnStr(str) (SpxBaseMgr::to_return_cstr(str))
-
-#define inputMgr SpxEngine::get_singleton()->get_input()
-#define audioMgr SpxEngine::get_singleton()->get_audio()
-#define physicMgr SpxEngine::get_singleton()->get_physic()
-#define spriteMgr SpxEngine::get_singleton()->get_sprite()
-#define resMgr SpxEngine::get_singleton()->get_res()
-#define uiMgr SpxEngine::get_singleton()->get_ui()
-#define cameraMgr SpxEngine::get_singleton()->get_camera()
-
-#define svgMgr SvgManager::get_singleton()
 
 #define NULL_OBJECT_ID 0
 

--- a/modules/spx/spx_camera_mgr.h
+++ b/modules/spx/spx_camera_mgr.h
@@ -36,7 +36,7 @@
 
 class Camera2D;
 
-class SpxCameraMgr : SpxBaseMgr {
+class SpxCameraMgr : public SpxBaseMgr {
 	SPXCLASS(SpxCameraMgr, SpxBaseMgr)
 
 public:

--- a/modules/spx/spx_debug_mgr.h
+++ b/modules/spx/spx_debug_mgr.h
@@ -50,7 +50,7 @@ struct DebugShape {
 	Node2D *node;
 };
 
-class SpxDebugMgr : SpxBaseMgr {
+class SpxDebugMgr : public SpxBaseMgr {
 	SPXCLASS(SpxDebugMgr, SpxBaseMgr)
 public:
 	virtual ~SpxDebugMgr() = default;

--- a/modules/spx/spx_ext_mgr.h
+++ b/modules/spx/spx_ext_mgr.h
@@ -36,7 +36,7 @@
 #include "spx_base_mgr.h"
 
 
-class SpxExtMgr : SpxBaseMgr {
+class SpxExtMgr : public SpxBaseMgr {
 	SPXCLASS(SpxExtMgr, SpxBaseMgr)
 public:
 	virtual ~SpxExtMgr() = default;

--- a/modules/spx/spx_mgr_access.h
+++ b/modules/spx/spx_mgr_access.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  spx_input_mgr.h                                                       */
+/*  spx_mgr_access.h                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,32 +28,38 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef SPX_INPUT_MGR_H
-#define SPX_INPUT_MGR_H
+#ifndef SPX_MGR_ACCESS_H
+#define SPX_MGR_ACCESS_H
 
-#include "gdextension_spx_ext.h"
-#include "spx_base_mgr.h"
-#include "spx_input_proxy.h"
+// Forward declaration to avoid circular dependency
+class SpxEngine;
+class SvgManager;
 
+/**
+ * @file spx_mgr_access.h
+ * @brief Unified accessor macros for all SPX manager instances
+ * 
+ * This header provides convenient macros to access manager singletons throughout
+ * the SPX module. All manager access macros are centralized here to avoid duplication.
+ */
 
+// SPX Manager access macros
+#define inputMgr SpxEngine::get_singleton()->get_input()
+#define audioMgr SpxEngine::get_singleton()->get_audio()
+#define physicMgr SpxEngine::get_singleton()->get_physic()
+#define spriteMgr SpxEngine::get_singleton()->get_sprite()
+#define uiMgr SpxEngine::get_singleton()->get_ui()
+#define sceneMgr SpxEngine::get_singleton()->get_scene()
+#define cameraMgr SpxEngine::get_singleton()->get_camera()
+#define platformMgr SpxEngine::get_singleton()->get_platform()
+#define resMgr SpxEngine::get_singleton()->get_res()
+#define extMgr SpxEngine::get_singleton()->get_ext()
+#define debugMgr SpxEngine::get_singleton()->get_debug()
+#define navigationMgr SpxEngine::get_singleton()->get_navigation()
+#define penMgr SpxEngine::get_singleton()->get_pen()
+#define tilemapMgr SpxEngine::get_singleton()->get_tilemap()
 
-class SpxInputMgr : public SpxBaseMgr {
-	SPXCLASS(SpxInputMgr, SpxBaseMgr)
-public:
-	virtual ~SpxInputMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor
-	virtual void on_start() override;
-	void on_reset(int reset_code) override;
-protected:
-	SpxInputProxy *input_proxy;
-public:
-	GdVec2 get_global_mouse_pos();
-	GdBool get_key(GdInt key);
-	GdBool get_mouse_state(GdInt mouse_id);
-	GdInt get_key_state(GdInt key);
-	GdFloat get_axis(GdString neg_action, GdString pos_action);
-	GdBool is_action_pressed(GdString action);
-	GdBool is_action_just_pressed(GdString action);
-	GdBool is_action_just_released(GdString action);
-};
+// SVG Manager access macro
+#define svgMgr SvgManager::get_singleton()
 
-#endif // SPX_INPUT_MGR_H
+#endif // SPX_MGR_ACCESS_H

--- a/modules/spx/spx_navigation_mgr.h
+++ b/modules/spx/spx_navigation_mgr.h
@@ -35,7 +35,7 @@
 #include "spx_base_mgr.h"
 #include "spx_path_finder.h"
 
-class SpxNavigationMgr : SpxBaseMgr {
+class SpxNavigationMgr : public SpxBaseMgr {
 	SPXCLASS(SpxNavigationMgr, SpxBaseMgr)
 public:
 	virtual ~SpxNavigationMgr() = default;

--- a/modules/spx/spx_physic_mgr.h
+++ b/modules/spx/spx_physic_mgr.h
@@ -68,7 +68,7 @@ enum class ColliderType {
 	CAPSULE = 4,
 	POLYGON = 5
 };
-class SpxPhysicMgr : SpxBaseMgr {
+class SpxPhysicMgr : public SpxBaseMgr {
 	SPXCLASS(SpxPhysicMgr, SpxBaseMgr)
 
 private:

--- a/modules/spx/spx_platform_mgr.h
+++ b/modules/spx/spx_platform_mgr.h
@@ -34,7 +34,7 @@
 #include "gdextension_spx_ext.h"
 #include "spx_base_mgr.h"
 
-class SpxPlatformMgr : SpxBaseMgr {
+class SpxPlatformMgr : public SpxBaseMgr {
 	SPXCLASS(SpxPlatformMgr, SpxBaseMgr)
 	String persistant_data_dir = "res://";
 public:

--- a/modules/spx/spx_res_mgr.h
+++ b/modules/spx/spx_res_mgr.h
@@ -60,8 +60,8 @@ struct AnimPayload {
 	int64_t max_bitmap;
 };
 
-class SpxResMgr : SpxBaseMgr {
-	SPXCLASS(SpxPlatformMgr, SpxBaseMgr)
+class SpxResMgr : public SpxBaseMgr {
+	SPXCLASS(SpxResMgr, SpxBaseMgr)
 
 public:
 	virtual ~SpxResMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor

--- a/modules/spx/spx_scene_mgr.h
+++ b/modules/spx/spx_scene_mgr.h
@@ -38,7 +38,7 @@ class ISortableSprite;
 class TileMapLayer;
 class SubViewport;
 
-class SpxSceneMgr : SpxBaseMgr {
+class SpxSceneMgr : public SpxBaseMgr {
 	SPXCLASS(SpxSceneMgr, SpxBaseMgr)
 
 private:	 

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -90,7 +90,7 @@ struct hash<TriggerPair> {
 }
 
 
-class SpxSpriteMgr : SpxBaseMgr {
+class SpxSpriteMgr : public SpxBaseMgr {
 	SPXCLASS(SpxSpriteMgr, SpxBaseMgr)
 public:
 	virtual ~SpxSpriteMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor

--- a/modules/spx/spx_tilemap_mgr.h
+++ b/modules/spx/spx_tilemap_mgr.h
@@ -36,7 +36,7 @@
 
 class SpxDrawTiles;
 
-class SpxTilemapMgr : SpxBaseMgr {
+class SpxTilemapMgr : public SpxBaseMgr {
 	SPXCLASS(SpxTilemapMgr, SpxBaseMgr)
 public:
 	virtual ~SpxTilemapMgr() = default;

--- a/modules/spx/spx_ui_mgr.h
+++ b/modules/spx/spx_ui_mgr.h
@@ -35,8 +35,8 @@
 #include "spx_engine.h"
 #include "spx_ui.h"
 class Node;
-class SpxUiMgr : SpxBaseMgr {
-	SPXCLASS(SpxUIMgr, SpxBaseMgr)
+class SpxUiMgr : public SpxBaseMgr {
+	SPXCLASS(SpxUiMgr, SpxBaseMgr)
 
 public:
 	virtual ~SpxUiMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor


### PR DESCRIPTION
Fix(spx): correct manager class inheritance and naming issues

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
