### PR TITLE
opt:get pointer to buffer data for faster access + pivot done

### DIFF
--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -1113,9 +1113,12 @@ void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {
 		return;
 	}
 	
-	// Read header
-	int update_count = static_cast<int>(*(SpxBaseMgr::get_array<float>(buffer, 0)));
-	int delete_count = static_cast<int>(*(SpxBaseMgr::get_array<float>(buffer, 1)));
+	// Get pointer to buffer data for faster access
+	const float* buffer_data = SpxBaseMgr::get_array<float>(buffer, 0);
+	
+	// Read header using direct array access
+	int update_count = static_cast<int>(buffer_data[0]);
+	int delete_count = static_cast<int>(buffer_data[1]);
 	
 	// Validate buffer size
 	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
@@ -1127,9 +1130,6 @@ void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {
 	}
 	
 	int idx = HEADER_SIZE;
-	
-	// Get pointer to buffer data for faster access
-	const float* buffer_data = SpxBaseMgr::get_array<float>(buffer, 0);
 	
 	// Process updates
 	for (int i = 0; i < update_count; i++) {

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -1128,17 +1128,21 @@ void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {
 	
 	int idx = HEADER_SIZE;
 	
+	// Get pointer to buffer data for faster access
+	const float* buffer_data = SpxBaseMgr::get_array<float>(buffer, 0);
+	
 	// Process updates
 	for (int i = 0; i < update_count; i++) {
-		// Extract sprite ID and data
-		auto sprite_id = static_cast<GdObj>(*(SpxBaseMgr::get_array<float>(buffer, idx)));
-		auto x = *(SpxBaseMgr::get_array<float>(buffer, idx + 1));
-		auto y = *(SpxBaseMgr::get_array<float>(buffer, idx + 2));
-		auto rotation = *(SpxBaseMgr::get_array<float>(buffer, idx + 3));
-		auto scale_x = *(SpxBaseMgr::get_array<float>(buffer, idx + 4));
-		auto scale_y = *(SpxBaseMgr::get_array<float>(buffer, idx + 5));
-		// Note: offsetX and offsetY (idx+6, idx+7) are reserved for future use
-		auto visible = *(SpxBaseMgr::get_array<float>(buffer, idx + 8)) != 0.0;
+		// Extract sprite ID and data using direct array access
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
+		auto x = buffer_data[idx + 1];
+		auto y = buffer_data[idx + 2];
+		auto rotation = buffer_data[idx + 3];
+		auto scale_x = buffer_data[idx + 4];
+		auto scale_y = buffer_data[idx + 5];
+		auto offset_x = buffer_data[idx + 6];
+		auto offset_y = buffer_data[idx + 7];
+		auto visible = buffer_data[idx + 8] != 0.0;
 		
 		idx += FIELDS_PER_SPRITE;
 		
@@ -1155,11 +1159,12 @@ void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {
 		sprite->set_scale(GdVec2(scale_x, scale_y));
 		sprite->set_visible(visible);
 		sprite->on_set_visible(visible);
+		sprite->set_pivot(GdVec2(offset_x, -offset_y));
 	}
 	
-	// Process deletes
+	// Process deletes using direct array access
 	for (int i = 0; i < delete_count; i++) {
-		auto sprite_id = static_cast<GdObj>(*(SpxBaseMgr::get_array<float>(buffer, idx)));
+		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
 		idx++;
 		
 		// Get sprite and destroy it


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
