### PR TITLE
fix: sprite animation pivot offset bug

### DIFF
--- a/modules/spx/spx_sprite.cpp
+++ b/modules/spx/spx_sprite.cpp
@@ -956,7 +956,7 @@ void SpxSprite::_on_frame_changed() {
 			current_frame
 		);
 		
-		Vector2 final_offset = base_offset + frame_offset;
+		Vector2 final_offset = base_offset - pivot_offset + frame_offset * _render_scale;
 		anim2d->set_offset(final_offset);
 	}
 }

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -1097,7 +1097,7 @@ void SpxSpriteMgr::set_pivot(GdObj obj, GdVec2 pivot){
 GdVec2 SpxSpriteMgr::get_pivot(GdObj obj){
 	SPX_REQUIRE_SPRITE_RETURN(GdVec2())
 	auto pivot= sprite->get_pivot();
-	return GdVec2(pivot.x,-pivot.y);
+	return GdVec2(pivot.x, -pivot.y);
 }
 
 void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
