### PR TITLE
Fix stale module registration during shared-tree template builds

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -30,18 +30,12 @@ modules_enabled = env.CommandNoCache(
 def register_module_types_builder(target, source, env):
     modules = source[0].read()
     mod_inc = "\n".join([f'#include "{p}/register_types.h"' for p in modules.values()])
-    mod_init = "\n".join(
-        [f"#ifdef MODULE_{n.upper()}_ENABLED\n\tinitialize_{n}_module(p_level);\n#endif" for n in modules.keys()]
-    )
-    mod_uninit = "\n".join(
-        [f"#ifdef MODULE_{n.upper()}_ENABLED\n\tuninitialize_{n}_module(p_level);\n#endif" for n in modules.keys()]
-    )
+    mod_init = "\n".join([f"\tinitialize_{n}_module(p_level);" for n in modules.keys()])
+    mod_uninit = "\n".join([f"\tuninitialize_{n}_module(p_level);" for n in modules.keys()])
     with methods.generated_wrapper(target) as file:
         file.write(
             f"""\
 #include "register_module_types.h"
-
-#include "modules/modules_enabled.gen.h"
 
 {mod_inc}
 
@@ -58,7 +52,7 @@ void uninitialize_modules(ModuleInitializationLevel p_level) {{
 
 register_module_types = env.CommandNoCache(
     "register_module_types.gen.cpp",
-    [env.Value(env.modules_detected), modules_enabled],
+    env.Value(env.module_list),
     env.Run(register_module_types_builder),
 )
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
