### PR TITLE
Fix memory leak in sprite batch raw updates

### DIFF
--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -1112,7 +1112,7 @@ GdVec2 SpxSpriteMgr::get_pivot(GdObj obj) {
 
 namespace {
 
-void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len) {
+void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len, const char *op_name) {
 	// Buffer format with header: [updateCount, deleteCount, update_data..., delete_ids...]
 	// - Header: [updateCount, deleteCount]
 	// - Update section: [id, x, y, rotation, scaleX, scaleY, offsetX, offsetY, visible, ...] (9 fields per sprite)
@@ -1135,7 +1135,7 @@ void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, i
 	// Validate buffer size
 	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
 	if (len != expected_size) {
-		print_error("batch_update_transforms: buffer size " + itos(len) +
+		print_error(String(op_name) + ": buffer size " + itos(len) +
 				" does not match expected size " + itos(expected_size) +
 				" (updateCount=" + itos(update_count) + ", deleteCount=" + itos(delete_count) + ")");
 		return;
@@ -1186,7 +1186,7 @@ void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, i
 	}
 }
 
-void batch_update_visuals_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len) {
+void batch_update_visuals_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len, const char *op_name) {
 	// Buffer format: [count, entry0..., entry1..., ...]
 	// Each entry (9 floats): [spriteId, renderScaleX, renderScaleY, zIndex, flags, uvX, uvY, uvW, uvH]
 	const int VISUAL_FIELDS_PER_SPRITE = 9;
@@ -1206,7 +1206,7 @@ void batch_update_visuals_impl(SpxSpriteMgr *mgr, const float *buffer_data, int 
 
 	int expected_size = HEADER_SIZE + count * VISUAL_FIELDS_PER_SPRITE;
 	if (len != expected_size) {
-		print_error("batch_update_visuals: buffer size " + itos(len) +
+		print_error(String(op_name) + ": buffer size " + itos(len) +
 				" does not match expected size " + itos(expected_size) +
 				" (count=" + itos(count) + ")");
 		return;
@@ -1261,7 +1261,7 @@ void SpxSpriteMgr::batch_update_transforms(GdArray buffer) {
 	}
 
 	const float *buffer_data = SpxBaseMgr::get_array<float>(buffer, 0);
-	batch_update_transforms_impl(this, buffer_data, len);
+	batch_update_transforms_impl(this, buffer_data, len, "batch_update_transforms");
 }
 
 void SpxSpriteMgr::batch_update_visuals(GdArray buffer) {
@@ -1275,7 +1275,23 @@ void SpxSpriteMgr::batch_update_visuals(GdArray buffer) {
 	}
 
 	const float *buffer_data = SpxBaseMgr::get_array<float>(buffer, 0);
-	batch_update_visuals_impl(this, buffer_data, len);
+	batch_update_visuals_impl(this, buffer_data, len, "batch_update_visuals");
+}
+
+void SpxSpriteMgr::batch_update_transforms_raw(const float *buffer_data, int len) {
+	if (buffer_data == nullptr || len < 2) {
+		return;
+	}
+
+	batch_update_transforms_impl(this, buffer_data, len, "batch_update_transforms_raw");
+}
+
+void SpxSpriteMgr::batch_update_visuals_raw(const float *buffer_data, int len) {
+	if (buffer_data == nullptr || len < 1) {
+		return;
+	}
+
+	batch_update_visuals_impl(this, buffer_data, len, "batch_update_visuals_raw");
 }
 
 GdArray SpxSpriteMgr::batch_retrieve_positions(GdArray objs) {

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -132,6 +132,9 @@ public:
 	void destroy_all_sprites();
 	void collect_sortable_sprites(Vector<ISortableSprite *> &out);
 
+	void batch_update_transforms_raw(const float *buffer_data, int len);
+	void batch_update_visuals_raw(const float *buffer_data, int len);
+
 public:
 	void set_dont_destroy_on_load(GdObj obj);
 	// process

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -35,7 +35,6 @@
 #include "core/extension/gdextension_interface.h"
 #include "scene/main/window.h"
 #include "modules/spx/spx_engine.h"
-#include "modules/spx/spx_sprite.h"
 #include "modules/spx/spx_audio_mgr.h"
 #include "modules/spx/spx_camera_mgr.h"
 #include "modules/spx/spx_debug_mgr.h"
@@ -68,117 +67,6 @@
 #define tilemapMgr SpxEngine::get_singleton()->get_tilemap()
 #define tilemapparserMgr SpxEngine::get_singleton()->get_tilemapparser()
 #define uiMgr SpxEngine::get_singleton()->get_ui()
-
-namespace {
-
-void gdspx_batch_update_transforms_raw(const float *buffer_data, int32_t len) {
-	const int FIELDS_PER_SPRITE = 9;
-	const int HEADER_SIZE = 2;
-
-	if (buffer_data == nullptr || len < HEADER_SIZE) {
-		return;
-	}
-
-	int update_count = static_cast<int>(buffer_data[0]);
-	int delete_count = static_cast<int>(buffer_data[1]);
-	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
-	if (len != expected_size) {
-		print_error("batch_update_transforms_raw: buffer size " + itos(len) +
-				" does not match expected size " + itos(expected_size) +
-				" (updateCount=" + itos(update_count) + ", deleteCount=" + itos(delete_count) + ")");
-		return;
-	}
-
-	int idx = HEADER_SIZE;
-	for (int i = 0; i < update_count; i++) {
-		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
-		auto x = buffer_data[idx + 1];
-		auto y = buffer_data[idx + 2];
-		auto rotation = buffer_data[idx + 3];
-		auto scale_x = buffer_data[idx + 4];
-		auto scale_y = buffer_data[idx + 5];
-		auto offset_x = buffer_data[idx + 6];
-		auto offset_y = buffer_data[idx + 7];
-		auto visible = buffer_data[idx + 8] != 0.0;
-
-		idx += FIELDS_PER_SPRITE;
-
-		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
-		if (sprite == nullptr) {
-			continue;
-		}
-
-		sprite->set_position(GdVec2(x, -y));
-		sprite->set_rotation(rotation);
-		sprite->set_scale(GdVec2(scale_x, scale_y));
-		sprite->set_visible(visible);
-		sprite->on_set_visible(visible);
-		sprite->set_pivot(GdVec2(offset_x, -offset_y));
-	}
-
-	for (int i = 0; i < delete_count; i++) {
-		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
-		idx++;
-
-		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
-		if (sprite != nullptr) {
-			sprite->set_block_signals(true);
-			sprite->queue_free();
-		}
-	}
-}
-
-void gdspx_batch_update_visuals_raw(const float *buffer_data, int32_t len) {
-	const int VISUAL_FIELDS_PER_SPRITE = 9;
-	const int HEADER_SIZE = 1;
-	const int FLAG_HAS_ZINDEX = 1;
-	const int FLAG_HAS_UV_REMAP = 2;
-
-	if (buffer_data == nullptr || len < HEADER_SIZE) {
-		return;
-	}
-
-	int count = static_cast<int>(buffer_data[0]);
-	int expected_size = HEADER_SIZE + count * VISUAL_FIELDS_PER_SPRITE;
-	if (len != expected_size) {
-		print_error("batch_update_visuals_raw: buffer size " + itos(len) +
-				" does not match expected size " + itos(expected_size) +
-				" (count=" + itos(count) + ")");
-		return;
-	}
-
-	int idx = HEADER_SIZE;
-	for (int i = 0; i < count; i++) {
-		auto sprite_id = static_cast<GdObj>(buffer_data[idx]);
-		auto render_scale_x = buffer_data[idx + 1];
-		auto render_scale_y = buffer_data[idx + 2];
-		auto z_index = static_cast<int>(buffer_data[idx + 3]);
-		auto flags = static_cast<int>(buffer_data[idx + 4]);
-		auto uv_x = buffer_data[idx + 5];
-		auto uv_y = buffer_data[idx + 6];
-		auto uv_w = buffer_data[idx + 7];
-		auto uv_h = buffer_data[idx + 8];
-
-		idx += VISUAL_FIELDS_PER_SPRITE;
-
-		SpxSprite *sprite = spriteMgr->get_sprite(sprite_id);
-		if (sprite == nullptr) {
-			continue;
-		}
-
-		sprite->set_render_scale(GdVec2(render_scale_x, render_scale_y));
-		if (flags & FLAG_HAS_ZINDEX) {
-			sprite->set_z_index(z_index);
-		}
-		if (flags & FLAG_HAS_UV_REMAP) {
-			String uv_param = "uv_remap";
-			sprite->set_material_params_vec4(SpxReturnStr(uv_param), GdVec4(uv_x, uv_y, uv_w, uv_h));
-		}
-	}
-}
-
-} // namespace
-
 
 extern "C" {
 // memory allocator for wrap codes
@@ -1185,7 +1073,7 @@ void gdspx_sprite_batch_update_transforms(GdArray* buffer) {
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_batch_update_transforms_raw(float *buffer_data, int32_t len) {
-	gdspx_batch_update_transforms_raw(buffer_data, len);
+	spriteMgr->batch_update_transforms_raw(buffer_data, len);
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_batch_update_visuals(GdArray* buffer) {
@@ -1193,7 +1081,7 @@ void gdspx_sprite_batch_update_visuals(GdArray* buffer) {
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_batch_update_visuals_raw(float *buffer_data, int32_t len) {
-	gdspx_batch_update_visuals_raw(buffer_data, len);
+	spriteMgr->batch_update_visuals_raw(buffer_data, len);
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_batch_retrieve_positions(GdArray* objs, GdArray *ret_val) {


### PR DESCRIPTION
- fixes the memory leak in sprite batch raw updates on web
- reduces duplicated logic in the web binding
- keeps transform/visual batch behavior aligned across entry points
