### PR TITLE
Web: Optimize no-thread audio transfer buffer reuse

### DIFF
--- a/platform/web/js/libs/audio.position.worklet.js
+++ b/platform/web/js/libs/audio.position.worklet.js
@@ -40,6 +40,12 @@ class GodotPositionReportingProcessor extends AudioWorkletProcessor {
 		this.port.onmessage = (event) => {
 			if (event?.data?.type === 'ended') {
 				this.ended = true;
+				return;
+			}
+			if (event?.data?.type === 'clear') {
+				this.ended = false;
+				this.position = Number(event.data.data) || 0;
+				this.lastPostTime = currentTime;
 			}
 		};
 	}

--- a/platform/web/js/libs/audio.worklet.js
+++ b/platform/web/js/libs/audio.worklet.js
@@ -104,6 +104,7 @@ class GodotProcessor extends AudioWorkletProcessor {
 		this.output_buffer = new Float32Array();
 		this.input = null;
 		this.input_buffer = new Float32Array();
+		this.input_transfer_pool = [];
 		this.port.onmessage = (event) => {
 			const cmd = event.data['cmd'];
 			const data = event.data['data'];
@@ -116,6 +117,17 @@ class GodotProcessor extends AudioWorkletProcessor {
 			Atomics.add(this.notifier, 0, 1);
 			Atomics.notify(this.notifier, 0);
 		}
+	}
+
+	static get_transfer_buffer(pool, size) {
+		for (let i = pool.length - 1; i >= 0; i--) {
+			const buffer = pool[i];
+			if (buffer.length === size) {
+				pool.splice(i, 1);
+				return buffer;
+			}
+		}
+		return new Float32Array(size);
 	}
 
 	parse_message(p_cmd, p_data) {
@@ -135,10 +147,20 @@ class GodotProcessor extends AudioWorkletProcessor {
 			this.input = null;
 			this.lock = null;
 			this.notifier = null;
+			this.input_transfer_pool.length = 0;
 		} else if (p_cmd === 'start_nothreads') {
 			this.output = new RingBuffer(p_data[0], p_data[0].length, false);
+			this.input_transfer_pool.length = 0;
 		} else if (p_cmd === 'chunk') {
-			this.output.write(p_data);
+			const buffer = p_data[0];
+			const size = p_data[1];
+			const chunk = new Float32Array(buffer, 0, size);
+			this.output.write(chunk);
+			this.port.postMessage({ 'cmd': 'chunk_recycle', 'data': buffer }, [buffer]);
+		} else if (p_cmd === 'input_recycle') {
+			if (p_data && this.input_transfer_pool.length < 8) {
+				this.input_transfer_pool.push(new Float32Array(p_data));
+			}
 		}
 	}
 
@@ -161,8 +183,9 @@ class GodotProcessor extends AudioWorkletProcessor {
 				this.input_buffer = new Float32Array(chunk);
 			}
 			if (!this.threads) {
-				GodotProcessor.write_input(this.input_buffer, input);
-				this.port.postMessage({ 'cmd': 'input', 'data': this.input_buffer });
+				const input_buffer = GodotProcessor.get_transfer_buffer(this.input_transfer_pool, chunk);
+				GodotProcessor.write_input(input_buffer, input);
+				this.port.postMessage({ 'cmd': 'input', 'data': [input_buffer.buffer, chunk] }, [input_buffer.buffer]);
 			} else if (this.input.space_left() >= chunk) {
 				GodotProcessor.write_input(this.input_buffer, input);
 				this.input.write(this.input_buffer);

--- a/platform/web/js/libs/audio.worklet.js
+++ b/platform/web/js/libs/audio.worklet.js
@@ -93,6 +93,10 @@ class RingBuffer {
 	}
 }
 
+// A small cap is enough because the no-thread input path can only keep a few
+// transferable chunks in flight between render quanta.
+const MAX_INPUT_TRANSFER_POOL_SIZE = 8;
+
 class GodotProcessor extends AudioWorkletProcessor {
 	constructor() {
 		super();
@@ -123,7 +127,8 @@ class GodotProcessor extends AudioWorkletProcessor {
 		for (let i = pool.length - 1; i >= 0; i--) {
 			const buffer = pool[i];
 			if (buffer.length === size) {
-				pool.splice(i, 1);
+				pool[i] = pool[pool.length - 1];
+				pool.pop();
 				return buffer;
 			}
 		}
@@ -158,7 +163,7 @@ class GodotProcessor extends AudioWorkletProcessor {
 			this.output.write(chunk);
 			this.port.postMessage({ 'cmd': 'chunk_recycle', 'data': buffer }, [buffer]);
 		} else if (p_cmd === 'input_recycle') {
-			if (p_data && this.input_transfer_pool.length < 8) {
+			if (p_data && this.input_transfer_pool.length < MAX_INPUT_TRANSFER_POOL_SIZE) {
 				this.input_transfer_pool.push(new Float32Array(p_data));
 			}
 		}
@@ -179,14 +184,14 @@ class GodotProcessor extends AudioWorkletProcessor {
 		if (process_input) {
 			const input = inputs[0];
 			const chunk = input[0].length * input.length;
-			if (this.input_buffer.length !== chunk) {
-				this.input_buffer = new Float32Array(chunk);
-			}
 			if (!this.threads) {
 				const input_buffer = GodotProcessor.get_transfer_buffer(this.input_transfer_pool, chunk);
 				GodotProcessor.write_input(input_buffer, input);
 				this.port.postMessage({ 'cmd': 'input', 'data': [input_buffer.buffer, chunk] }, [input_buffer.buffer]);
 			} else if (this.input.space_left() >= chunk) {
+				if (this.input_buffer.length !== chunk) {
+					this.input_buffer = new Float32Array(chunk);
+				}
 				GodotProcessor.write_input(this.input_buffer, input);
 				this.input.write(this.input_buffer);
 			} else {

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -431,8 +431,11 @@ class SampleNode {
 		this._onended = null;
 		/** @type {AudioWorkletNode | null} */
 		this._positionWorklet = null;
+		/** @type {Promise<void> | null} */
 		this._positionWorkletPromise = null;
 		this._positionWorker = null;
+		/** @type {number} */
+		this._sourceStartOffset = this.offset;
 
 		this.setPlaybackRate(options.playbackRate ?? 44100);
 		this._source.buffer = this.getSample().getAudioBuffer();
@@ -457,6 +460,7 @@ class SampleNode {
 
 	/**
 	 * Gets the playback position.
+	 * May lazily initialize the position reporter while playback is active.
 	 * @returns {number}
 	 */
 	getPlaybackPosition() {
@@ -469,12 +473,21 @@ class SampleNode {
 		return this._playbackPosition;
 	}
 
+	/**
+	 * Reports a position-worklet initialization failure.
+	 * @param {Error} err
+	 * @returns {void}
+	 */
 	_reportPositionWorkletError(err) {
 		const newErr = new Error('Failed to create PositionWorklet.');
 		newErr.cause = err;
 		GodotRuntime.error(newErr);
 	}
 
+	/**
+	 * Estimates the playback position between reporter updates.
+	 * @returns {number}
+	 */
 	_estimatePlaybackPosition() {
 		if (this.isPaused) {
 			return this.offset + this.pauseTime;
@@ -482,7 +495,21 @@ class SampleNode {
 		if (!this.isStarted || !GodotAudio.ctx) {
 			return this._playbackPosition;
 		}
-		return this.offset + Math.max(GodotAudio.ctx.currentTime - this._sourceStartTime, 0);
+		const playbackRate = this._source ? this._source.playbackRate.value : this.getPlaybackRate() * this.getPitchScale();
+		return this._sourceStartOffset + Math.max(GodotAudio.ctx.currentTime - this._sourceStartTime, 0) * playbackRate;
+	}
+
+	/**
+	 * Anchors future playback-position estimates to the current audio clock.
+	 * @param {number} position
+	 * @returns {void}
+	 */
+	_setPlaybackPositionAnchor(position) {
+		this._playbackPosition = position;
+		this._sourceStartOffset = position;
+		if (GodotAudio.ctx) {
+			this._resetSourceStartTime();
+		}
 	}
 
 	/**
@@ -537,7 +564,7 @@ class SampleNode {
 		if (this.isStarted) {
 			return;
 		}
-		this._resetSourceStartTime();
+		this._setPlaybackPositionAnchor(this.offset);
 		this._source.start(this.startTime, this.offset);
 		this.isStarted = true;
 	}
@@ -556,7 +583,6 @@ class SampleNode {
 	restart() {
 		this.isPaused = false;
 		this.pauseTime = 0;
-		this._resetSourceStartTime();
 		this._restart();
 	}
 
@@ -621,7 +647,7 @@ class SampleNode {
 	async connectPositionWorklet(start) {
 		if (this._positionWorkletPromise != null) {
 			await this._positionWorkletPromise;
-			if (start) {
+			if (start && !this.isCanceled && this._source != null) {
 				this.start();
 			}
 			return;
@@ -649,7 +675,7 @@ class SampleNode {
 		} finally {
 			this._positionWorkletPromise = null;
 		}
-		if (start) {
+		if (start && !this.isCanceled && this._source != null) {
 			this.start();
 		}
 	}
@@ -670,7 +696,7 @@ class SampleNode {
 			this._positionWorklet.port.onmessage = (event) => {
 				switch (event.data['type']) {
 				case 'position':
-					this._playbackPosition = parseInt(event.data.data, 10) / this.getSample().sampleRate;
+					this._setPlaybackPositionAnchor(parseInt(event.data.data, 10) / this.getSample().sampleRate);
 					break;
 				default:
 					// Do nothing.
@@ -693,7 +719,7 @@ class SampleNode {
 			if (typeof positionWorker !== 'undefined') {
 				positionWorker.onMessage(event => {
 					if (event.type === 'position') {
-						this._playbackPosition = parseInt(event.data, 10) / this.getSample().sampleRate + this.offset;
+						this._setPlaybackPositionAnchor(parseInt(event.data, 10) / this.getSample().sampleRate + this.offset);
 					}
 				});
 			}
@@ -760,6 +786,9 @@ class SampleNode {
 	 * @returns {void}
 	 */
 	_syncPlaybackRate() {
+		if (this.isStarted && !this.isPaused && GodotAudio.ctx && this._source != null) {
+			this._setPlaybackPositionAnchor(this._estimatePlaybackPosition());
+		}
 		this._source.playbackRate.value = this.getPlaybackRate() * this.getPitchScale();
 	}
 
@@ -774,6 +803,7 @@ class SampleNode {
 		}
 		this._source = GodotAudio.ctx.createBufferSource();
 		this._source.buffer = this.getSample().getAudioBuffer();
+		this._source.playbackRate.value = this.getPlaybackRate() * this.getPitchScale();
 
 		// Make sure that we connect the new source to the sample node bus.
 		for (const sampleNodeBus of this._sampleNodeBuses.values()) {
@@ -784,6 +814,7 @@ class SampleNode {
 		const pauseTime = this.isPaused
 			? this.pauseTime
 			: 0;
+		this._setPlaybackPositionAnchor(this.offset + pauseTime);
 		if (this._positionWorklet != null) {
 			if(typeof miniEngine === 'undefined' || !miniEngine){
 				this._positionWorklet.port.postMessage({
@@ -809,9 +840,13 @@ class SampleNode {
 		if (!this.isStarted) {
 			return;
 		}
+		const pauseTime = GodotAudio.ctx
+			? Math.max(this._estimatePlaybackPosition() - this.offset, 0)
+			: this.pauseTime;
 		this.isPaused = true;
 		if(GodotAudio.ctx){
-			this.pauseTime = (GodotAudio.ctx.currentTime - this._sourceStartTime) / this.getPlaybackRate();
+			this.pauseTime = pauseTime;
+			this._playbackPosition = this.offset + this.pauseTime;
 			this._source.stop();
 		}
 	}
@@ -2084,7 +2119,8 @@ const GodotAudioWorklet = {
 					for (let i = output_pool.length - 1; i >= 0; i--) {
 						const buffer = output_pool[i];
 						if (buffer.length === size) {
-							output_pool.splice(i, 1);
+							output_pool[i] = output_pool[output_pool.length - 1];
+							output_pool.pop();
 							return buffer;
 						}
 					}
@@ -2139,6 +2175,8 @@ const GodotAudioWorklet = {
 
 				this.recycleOutput = function (buffer) {
 					if (buffer && output_pool.length < MAX_OUTPUT_POOL_SIZE) {
+						// Keep mismatched recycled buffers in the pool to avoid extra
+						// churn if the render quantum size flips again later.
 						output_pool.push(new Float32Array(buffer));
 					}
 				};

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -404,7 +404,7 @@ class SampleNode {
 		/** @type {number} */
 		this.offset = options.offset ?? 0;
 		/** @type {number} */
-		this._playbackPosition = options.offset;
+		this._playbackPosition = this.offset;
 		/** @type {number} */
 		this.startTime = options.startTime ?? 0;
 		/** @type {boolean} */
@@ -431,6 +431,7 @@ class SampleNode {
 		this._onended = null;
 		/** @type {AudioWorkletNode | null} */
 		this._positionWorklet = null;
+		this._positionWorkletPromise = null;
 		this._positionWorker = null;
 
 		this.setPlaybackRate(options.playbackRate ?? 44100);
@@ -441,12 +442,9 @@ class SampleNode {
 		const bus = GodotAudio.Bus.getBus(params.busIndex);
 		const sampleNodeBus = this.getSampleNodeBus(bus);
 		sampleNodeBus.setVolume(options.volume);
-
-		this.connectPositionWorklet(options.start).catch((err) => {
-			const newErr = new Error('Failed to create PositionWorklet.');
-			newErr.cause = err;
-			GodotRuntime.error(newErr);
-		});
+		if (options.start) {
+			this.start();
+		}
 	}
 
 	/**
@@ -462,7 +460,29 @@ class SampleNode {
 	 * @returns {number}
 	 */
 	getPlaybackPosition() {
+		this._playbackPosition = this._estimatePlaybackPosition();
+		if (this.isStarted && !this.isCanceled && this._positionWorklet == null && this._positionWorkletPromise == null) {
+			this.connectPositionWorklet(false).catch((err) => {
+				this._reportPositionWorkletError(err);
+			});
+		}
 		return this._playbackPosition;
+	}
+
+	_reportPositionWorkletError(err) {
+		const newErr = new Error('Failed to create PositionWorklet.');
+		newErr.cause = err;
+		GodotRuntime.error(newErr);
+	}
+
+	_estimatePlaybackPosition() {
+		if (this.isPaused) {
+			return this.offset + this.pauseTime;
+		}
+		if (!this.isStarted || !GodotAudio.ctx) {
+			return this._playbackPosition;
+		}
+		return this.offset + Math.max(GodotAudio.ctx.currentTime - this._sourceStartTime, 0);
 	}
 
 	/**
@@ -599,13 +619,36 @@ class SampleNode {
 	 * If the worklet module is not loaded in, it will be added
 	 */
 	async connectPositionWorklet(start) {
-		if(typeof miniEngine === 'undefined' || !miniEngine){	
-			await GodotAudio.audioPositionWorkletPromise;
-		}
-		if (this.isCanceled) {
+		if (this._positionWorkletPromise != null) {
+			await this._positionWorkletPromise;
+			if (start) {
+				this.start();
+			}
 			return;
 		}
-		this._source.connect(this.getPositionWorklet());
+		this._positionWorkletPromise = (async () => {
+			const initialPosition = this._estimatePlaybackPosition();
+			const initialPositionFrames = Math.round(initialPosition * this.getSample().sampleRate);
+
+			if(typeof miniEngine === 'undefined' || !miniEngine){	
+				await GodotAudio.audioPositionWorkletPromise;
+			}
+			if (this.isCanceled || this._source == null) {
+				return;
+			}
+			const positionWorklet = this.getPositionWorklet();
+			if(typeof miniEngine === 'undefined' || !miniEngine){
+				positionWorklet.port.postMessage({ type: 'clear', data: initialPositionFrames });
+			}else if (this._positionWorker) {
+				this._positionWorker.postMessage({type: 'clear'});
+			}
+			this._source.connect(positionWorklet);
+		})();
+		try {
+			await this._positionWorkletPromise;
+		} finally {
+			this._positionWorkletPromise = null;
+		}
 		if (start) {
 			this.start();
 		}
@@ -627,7 +670,7 @@ class SampleNode {
 			this._positionWorklet.port.onmessage = (event) => {
 				switch (event.data['type']) {
 				case 'position':
-					this._playbackPosition = (parseInt(event.data.data, 10) / this.getSample().sampleRate) + this.offset;
+					this._playbackPosition = parseInt(event.data.data, 10) / this.getSample().sampleRate;
 					break;
 				default:
 					// Do nothing.
@@ -699,6 +742,7 @@ class SampleNode {
 			}
 			this._positionWorklet = null;
 		}
+		this._positionWorkletPromise = null;
 
 		GodotAudio.SampleNode.delete(this.id);
 	}
@@ -742,7 +786,10 @@ class SampleNode {
 			: 0;
 		if (this._positionWorklet != null) {
 			if(typeof miniEngine === 'undefined' || !miniEngine){
-				this._positionWorklet.port.postMessage({ type: 'clear' });
+				this._positionWorklet.port.postMessage({
+					type: 'clear',
+					data: Math.round((this.offset + pauseTime) * this.getSample().sampleRate),
+				});
 			}else{
 				if (this._positionWorker) {
 					this._positionWorker.postMessage({type: 'clear'});
@@ -2024,40 +2071,57 @@ const GodotAudioWorklet = {
 			p_in_size,
 			in_callback
 		) {
-			function RingBuffer() {
+			const MAX_OUTPUT_POOL_SIZE = 32;
+
+			function NoThreadTransport() {
 				let wpos = 0;
 				let rpos = 0;
 				let pending_samples = 0;
-				const wbuf = new Float32Array(p_out_size);
+				let output_chunk_size = 0;
+				const output_pool = [];
+
+				function acquireOutputBuffer(size) {
+					for (let i = output_pool.length - 1; i >= 0; i--) {
+						const buffer = output_pool[i];
+						if (buffer.length === size) {
+							output_pool.splice(i, 1);
+							return buffer;
+						}
+					}
+					return new Float32Array(size);
+				}
 
 				function send(port) {
 					if (pending_samples === 0) {
 						return;
 					}
+					const chunk_size = output_chunk_size > 0 ? output_chunk_size : pending_samples;
 					const buffer = GodotRuntime.heapSub(HEAPF32, p_out_buf, p_out_size);
 					const size = buffer.length;
-					const tot_sent = pending_samples;
-					out_callback(wpos, pending_samples);
-					if (wpos + pending_samples >= size) {
-						const high = size - wpos;
-						wbuf.set(buffer.subarray(wpos, size));
-						pending_samples -= high;
-						wpos = 0;
-					}
-					if (pending_samples > 0) {
-						wbuf.set(
-							buffer.subarray(wpos, wpos + pending_samples),
-							tot_sent - pending_samples
+					while (pending_samples > 0) {
+						const to_send = Math.min(pending_samples, chunk_size);
+						const chunk = acquireOutputBuffer(to_send);
+						out_callback(wpos, to_send);
+						if (wpos + to_send > size) {
+							const high = size - wpos;
+							chunk.set(buffer.subarray(wpos, size));
+							chunk.set(buffer.subarray(0, to_send - high), high);
+						} else {
+							chunk.set(buffer.subarray(wpos, wpos + to_send));
+						}
+						port.postMessage(
+							{ 'cmd': 'chunk', 'data': [chunk.buffer, to_send] },
+							[chunk.buffer]
 						);
+						wpos = (wpos + to_send) % size;
+						pending_samples -= to_send;
 					}
-					port.postMessage({ 'cmd': 'chunk', 'data': wbuf.subarray(0, tot_sent) });
-					wpos += pending_samples;
-					pending_samples = 0;
 				}
-				this.receive = function (recv_buf) {
+
+				this.receive = function (recv_buf, recv_size, port) {
 					const buffer = GodotRuntime.heapSub(HEAPF32, p_in_buf, p_in_size);
 					const from = rpos;
-					let to_write = recv_buf.length;
+					let to_write = recv_size;
 					let high = 0;
 					if (rpos + to_write >= p_in_size) {
 						high = p_in_size - rpos;
@@ -2066,17 +2130,27 @@ const GodotAudioWorklet = {
 						rpos = 0;
 					}
 					if (to_write) {
-						buffer.set(recv_buf.subarray(high, to_write), rpos);
+						buffer.set(recv_buf.subarray(high, high + to_write), rpos);
 					}
-					in_callback(from, recv_buf.length);
+					in_callback(from, recv_size);
 					rpos += to_write;
+					port.postMessage({ 'cmd': 'input_recycle', 'data': recv_buf.buffer }, [recv_buf.buffer]);
 				};
+
+				this.recycleOutput = function (buffer) {
+					if (buffer && output_pool.length < MAX_OUTPUT_POOL_SIZE) {
+						output_pool.push(new Float32Array(buffer));
+					}
+				};
+
 				this.consumed = function (size, port) {
+					output_chunk_size = size;
 					pending_samples += size;
 					send(port);
 				};
 			}
-			GodotAudioWorklet.ring_buffer = new RingBuffer();
+
+			GodotAudioWorklet.ring_buffer = new NoThreadTransport();
 			GodotAudioWorklet.promise.then(function () {
 				const node = GodotAudioWorklet.worklet;
 				const buffer = GodotRuntime.heapSlice(HEAPF32, p_out_buf, p_out_size);
@@ -2084,7 +2158,7 @@ const GodotAudioWorklet = {
 				node.port.postMessage({
 					'cmd': 'start_nothreads',
 					'data': [buffer, p_in_size],
-				});
+				}, [buffer.buffer]);
 				node.port.onmessage = function (event) {
 					if (!GodotAudioWorklet.worklet) {
 						return;
@@ -2095,13 +2169,20 @@ const GodotAudioWorklet = {
 							read,
 							GodotAudioWorklet.worklet.port
 						);
+					} else if (event.data['cmd'] === 'chunk_recycle') {
+						GodotAudioWorklet.ring_buffer.recycleOutput(event.data['data']);
 					} else if (event.data['cmd'] === 'input') {
-						const buf = event.data['data'];
-						if (buf.length > p_in_size) {
+						const input_buffer = event.data['data'][0];
+						const input_size = event.data['data'][1];
+						if ((input_size || 0) > p_in_size) {
 							GodotRuntime.error('Input chunk is too big');
 							return;
 						}
-						GodotAudioWorklet.ring_buffer.receive(buf);
+						GodotAudioWorklet.ring_buffer.receive(
+							new Float32Array(input_buffer, 0, input_size),
+							input_size,
+							GodotAudioWorklet.worklet.port
+						);
 					} else {
 						GodotRuntime.error(event.data);
 					}
@@ -2127,6 +2208,7 @@ const GodotAudioWorklet = {
 					GodotAudioWorklet.worklet.disconnect();
 					GodotAudioWorklet.worklet.port.onmessage = null;
 					GodotAudioWorklet.worklet = null;
+					GodotAudioWorklet.ring_buffer = null;
 					GodotAudioWorklet.promise = null;
 					resolve();
 				}).catch(function (err) {


### PR DESCRIPTION
1.reduce no-thread audio overhead
2.recycle no-thread worklet transfer buffers
3.keep mismatched transfer buffers in pool

