### PR TITLE
refactor(spx): mark manager ABI methods explicitly

### DIFF
--- a/modules/spx/spx_audio_mgr.h
+++ b/modules/spx/spx_audio_mgr.h
@@ -61,29 +61,29 @@ public:
 	void on_update(float delta) override;
 	void on_reset(int reset_code) override;
 
-	void stop_all();
-	GdObj create_audio();
-	void destroy_audio(GdObj obj);
+	SPX_API void stop_all();
+	SPX_API GdObj create_audio();
+	SPX_API void destroy_audio(GdObj obj);
 
-	void set_pitch(GdObj obj, GdFloat pitch);
-	GdFloat get_pitch(GdObj obj);
-	void set_pan(GdObj obj, GdFloat pan);
-	GdFloat get_pan(GdObj obj);
-	void set_volume(GdObj obj, GdFloat volume);
-	GdFloat get_volume(GdObj obj);
+	SPX_API void set_pitch(GdObj obj, GdFloat pitch);
+	SPX_API GdFloat get_pitch(GdObj obj);
+	SPX_API void set_pan(GdObj obj, GdFloat pan);
+	SPX_API GdFloat get_pan(GdObj obj);
+	SPX_API void set_volume(GdObj obj, GdFloat volume);
+	SPX_API GdFloat get_volume(GdObj obj);
 
 	// play audio and return the audioid
-	GdInt play_with_attenuation(GdObj obj, GdString path, GdObj owner_id, GdFloat attenuation, GdFloat max_distance);
-	GdInt play(GdObj obj, GdString path);
-	void pause(GdInt aid);
-	void resume(GdInt aid);
-	void stop(GdInt aid);
-	void set_loop(GdInt aid, GdBool loop);
-	GdBool get_loop(GdInt aid);
+	SPX_API GdInt play_with_attenuation(GdObj obj, GdString path, GdObj owner_id, GdFloat attenuation, GdFloat max_distance);
+	SPX_API GdInt play(GdObj obj, GdString path);
+	SPX_API void pause(GdInt aid);
+	SPX_API void resume(GdInt aid);
+	SPX_API void stop(GdInt aid);
+	SPX_API void set_loop(GdInt aid, GdBool loop);
+	SPX_API GdBool get_loop(GdInt aid);
 
-	GdFloat get_timer(GdInt aid);
-	void set_timer(GdInt aid, GdFloat time);
-	GdBool is_playing(GdInt aid);
+	SPX_API GdFloat get_timer(GdInt aid);
+	SPX_API void set_timer(GdInt aid, GdFloat time);
+	SPX_API GdBool is_playing(GdInt aid);
 };
 
 #endif // SPX_AUDIO_MGR_H

--- a/modules/spx/spx_base_mgr.h
+++ b/modules/spx/spx_base_mgr.h
@@ -46,6 +46,14 @@ public:                                      \
 #define SpxStr(str) (String::utf8((const char *)str))
 #define SpxReturnStr(str) (SpxBaseMgr::to_return_cstr(str))
 
+#ifndef SPX_API
+#define SPX_API
+#endif
+
+#ifndef SPX_BIND
+#define SPX_BIND SPX_API
+#endif
+
 #define NULL_OBJECT_ID 0
 
 class Window;

--- a/modules/spx/spx_camera_mgr.h
+++ b/modules/spx/spx_camera_mgr.h
@@ -53,15 +53,15 @@ public:
 	void set_stretch_clear_color();
 
 public:
-	GdVec2 get_camera_position();
-	void set_camera_position(GdVec2 position);
-	GdVec2 get_camera_zoom();
-	void set_camera_zoom(GdVec2 size);
-	GdRect2 get_viewport_rect();
-	GdRect2 get_global_camera_rect();
-	GdRect2 get_stage_limits_rect();
-	void set_camera_limit(GdInt side, GdInt limit);
-	void set_camera_smoothing(GdBool enabled);
+	SPX_API GdVec2 get_camera_position();
+	SPX_API void set_camera_position(GdVec2 position);
+	SPX_API GdVec2 get_camera_zoom();
+	SPX_API void set_camera_zoom(GdVec2 size);
+	SPX_API GdRect2 get_viewport_rect();
+	SPX_API GdRect2 get_global_camera_rect();
+	SPX_API GdRect2 get_stage_limits_rect();
+	SPX_API void set_camera_limit(GdInt side, GdInt limit);
+	SPX_API void set_camera_smoothing(GdBool enabled);
 };
 
 #endif // SPX_CAMERA_MGR_H

--- a/modules/spx/spx_debug_mgr.h
+++ b/modules/spx/spx_debug_mgr.h
@@ -68,9 +68,9 @@ public:
 	void on_destroy() override;
 	void on_reset(int reset_code) override;
 
-	void debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color);
-	void debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color);
-	void debug_draw_line(GdVec2 from, GdVec2 to, GdColor color);
+	SPX_API void debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color);
+	SPX_API void debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color);
+	SPX_API void debug_draw_line(GdVec2 from, GdVec2 to, GdColor color);
 };
 
 #endif // SPX_DEBUG_MGR_H

--- a/modules/spx/spx_ext_mgr.h
+++ b/modules/spx/spx_ext_mgr.h
@@ -42,18 +42,18 @@ public:
 
 public:
 	// engine API
-	void request_exit(GdInt exit_code);
-	void request_reset(GdInt exit_code);
-	void request_restart();
-	void on_runtime_panic(GdString msg);
+	SPX_API void request_exit(GdInt exit_code);
+	SPX_API void request_reset(GdInt exit_code);
+	SPX_API void request_restart();
+	SPX_API void on_runtime_panic(GdString msg);
 	// pause API
-	void pause();
-	void resume();
-	GdBool is_paused();
-	void next_frame();
+	SPX_API void pause();
+	SPX_API void resume();
+	SPX_API GdBool is_paused();
+	SPX_API void next_frame();
 
 	// layer sorter
-	void set_layer_sorter_mode(GdInt mode);
+	SPX_API void set_layer_sorter_mode(GdInt mode);
 };
 
 #endif // SPX_EXT_MGR_H

--- a/modules/spx/spx_input_mgr.h
+++ b/modules/spx/spx_input_mgr.h
@@ -46,14 +46,14 @@ protected:
 	SpxInputProxy *input_proxy = nullptr;
 
 public:
-	GdVec2 get_global_mouse_pos();
-	GdBool get_key(GdInt key);
-	GdBool get_mouse_state(GdInt mouse_id);
-	GdInt get_key_state(GdInt key);
-	GdFloat get_axis(GdString neg_action, GdString pos_action);
-	GdBool is_action_pressed(GdString action);
-	GdBool is_action_just_pressed(GdString action);
-	GdBool is_action_just_released(GdString action);
+	SPX_API GdVec2 get_global_mouse_pos();
+	SPX_API GdBool get_key(GdInt key);
+	SPX_API GdBool get_mouse_state(GdInt mouse_id);
+	SPX_API GdInt get_key_state(GdInt key);
+	SPX_API GdFloat get_axis(GdString neg_action, GdString pos_action);
+	SPX_API GdBool is_action_pressed(GdString action);
+	SPX_API GdBool is_action_just_pressed(GdString action);
+	SPX_API GdBool is_action_just_released(GdString action);
 };
 
 #endif // SPX_INPUT_MGR_H

--- a/modules/spx/spx_navigation_mgr.h
+++ b/modules/spx/spx_navigation_mgr.h
@@ -47,10 +47,10 @@ private:
 	const GdVec2 default_cell_size{ 16, 16 };
 
 public:
-	void setup_path_finder_with_size(GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug);
-	void setup_path_finder(GdBool with_jump);
-	void set_obstacle(GdObj obj, GdBool enabled);
-	GdArray find_path(GdVec2 p_from, GdVec2 p_to, GdBool with_jump);
+	SPX_API void setup_path_finder_with_size(GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug);
+	SPX_API void setup_path_finder(GdBool with_jump);
+	SPX_API void set_obstacle(GdObj obj, GdBool enabled);
+	SPX_API GdArray find_path(GdVec2 p_from, GdVec2 p_to, GdBool with_jump);
 };
 
 #endif // SPX_NAVIGATION_MGR_H

--- a/modules/spx/spx_pen_mgr.h
+++ b/modules/spx/spx_pen_mgr.h
@@ -45,20 +45,20 @@ public:
 	void on_destroy() override;
 	void on_reset(int reset_code) override;
 
-	void destroy_all_pens();
-	GdObj create_pen();
-	void destroy_pen(GdObj obj);
+	SPX_API void destroy_all_pens();
+	SPX_API GdObj create_pen();
+	SPX_API void destroy_pen(GdObj obj);
 	// Pen operation methods
-	void pen_stamp(GdObj obj);
-	void move_pen_to(GdObj obj, GdVec2 position);
-	void pen_down(GdObj obj, GdBool move_by_mouse);
-	void pen_up(GdObj obj);
-	void set_pen_color_to(GdObj obj, GdColor color);
-	void change_pen_by(GdObj obj, GdInt property, GdFloat amount);
-	void set_pen_to(GdObj obj, GdInt property, GdFloat value);
-	void change_pen_size_by(GdObj obj, GdFloat amount);
-	void set_pen_size_to(GdObj obj, GdFloat size);
-	void set_pen_stamp_texture(GdObj obj, GdString texture_path);
+	SPX_API void pen_stamp(GdObj obj);
+	SPX_API void move_pen_to(GdObj obj, GdVec2 position);
+	SPX_API void pen_down(GdObj obj, GdBool move_by_mouse);
+	SPX_API void pen_up(GdObj obj);
+	SPX_API void set_pen_color_to(GdObj obj, GdColor color);
+	SPX_API void change_pen_by(GdObj obj, GdInt property, GdFloat amount);
+	SPX_API void set_pen_to(GdObj obj, GdInt property, GdFloat value);
+	SPX_API void change_pen_size_by(GdObj obj, GdFloat amount);
+	SPX_API void set_pen_size_to(GdObj obj, GdFloat size);
+	SPX_API void set_pen_stamp_texture(GdObj obj, GdString texture_path);
 };
 
 #endif // SPX_PEN_MGR_H

--- a/modules/spx/spx_physics_mgr.h
+++ b/modules/spx/spx_physics_mgr.h
@@ -97,30 +97,30 @@ public:
 
 public:
 	virtual ~SpxPhysicsMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor
-	GdObj raycast(GdVec2 from, GdVec2 to, GdInt collision_mask);
-	GdBool check_collision(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies);
-	GdInt check_touched_camera_boundaries(GdObj obj);
-	GdBool check_touched_camera_boundary(GdObj obj, GdInt board_type);
-	GdInt check_nearest_touched_camera_boundary(GdObj obj);
+	SPX_API GdObj raycast(GdVec2 from, GdVec2 to, GdInt collision_mask);
+	SPX_API GdBool check_collision(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies);
+	SPX_API GdInt check_touched_camera_boundaries(GdObj obj);
+	SPX_API GdBool check_touched_camera_boundary(GdObj obj, GdInt board_type);
+	SPX_API GdInt check_nearest_touched_camera_boundary(GdObj obj);
 
 	// Stage boundary check functions
-	GdInt check_touched_stage_boundaries(GdObj obj);
-	GdBool check_touched_stage_boundary(GdObj obj, GdInt board_type);
-	GdInt check_nearest_touched_stage_boundary(GdObj obj);
-	void set_collision_system_type(GdBool is_collision_by_alpha);
+	SPX_API GdInt check_touched_stage_boundaries(GdObj obj);
+	SPX_API GdBool check_touched_stage_boundary(GdObj obj, GdInt board_type);
+	SPX_API GdInt check_nearest_touched_stage_boundary(GdObj obj);
+	SPX_API void set_collision_system_type(GdBool is_collision_by_alpha);
 
 	// configs
-	void set_global_gravity(GdFloat gravity);
-	GdFloat get_global_gravity();
-	void set_global_friction(GdFloat friction);
-	GdFloat get_global_friction();
-	void set_global_air_drag(GdFloat air_drag);
-	GdFloat get_global_air_drag();
+	SPX_API void set_global_gravity(GdFloat gravity);
+	SPX_API GdFloat get_global_gravity();
+	SPX_API void set_global_friction(GdFloat friction);
+	SPX_API GdFloat get_global_friction();
+	SPX_API void set_global_air_drag(GdFloat air_drag);
+	SPX_API GdFloat get_global_air_drag();
 
 	// check collision
-	GdArray check_collision_rect(GdVec2 pos, GdVec2 size, GdInt collision_mask);
-	GdArray check_collision_circle(GdVec2 pos, GdFloat radius, GdInt collision_mask);
-	GdArray raycast_with_details(GdVec2 from, GdVec2 to, GdArray ignore_sprites, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies);
+	SPX_API GdArray check_collision_rect(GdVec2 pos, GdVec2 size, GdInt collision_mask);
+	SPX_API GdArray check_collision_circle(GdVec2 pos, GdFloat radius, GdInt collision_mask);
+	SPX_API GdArray raycast_with_details(GdVec2 from, GdVec2 to, GdArray ignore_sprites, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies);
 };
 
 #endif // SPX_PHYSICS_MGR_H

--- a/modules/spx/spx_platform_mgr.h
+++ b/modules/spx/spx_platform_mgr.h
@@ -48,30 +48,30 @@ public:
 
 public:
 	//Expose as few interfaces as possible to prevent misuse.
-	void set_stretch_mode(GdBool enable);
-	void set_stretch_aspect(GdBool is_keep);
-	void set_stretch_content_scale(GdInt width, GdInt height);
+	SPX_API void set_stretch_mode(GdBool enable);
+	SPX_API void set_stretch_aspect(GdBool is_keep);
+	SPX_API void set_stretch_content_scale(GdInt width, GdInt height);
 
-	void set_window_position(GdVec2 pos);
-	GdVec2 get_window_position();
-	void set_window_size(GdInt width, GdInt height, GdBool with_content_scale);
-	GdVec2 get_window_size();
-	void set_window_title(GdString title);
-	GdString get_window_title();
-	void set_window_fullscreen(GdBool enable);
-	GdBool is_window_fullscreen();
-	void set_debug_mode(GdBool enable);
-	GdBool is_debug_mode();
+	SPX_API void set_window_position(GdVec2 pos);
+	SPX_API GdVec2 get_window_position();
+	SPX_API void set_window_size(GdInt width, GdInt height, GdBool with_content_scale);
+	SPX_API GdVec2 get_window_size();
+	SPX_API void set_window_title(GdString title);
+	SPX_API GdString get_window_title();
+	SPX_API void set_window_fullscreen(GdBool enable);
+	SPX_API GdBool is_window_fullscreen();
+	SPX_API void set_debug_mode(GdBool enable);
+	SPX_API GdBool is_debug_mode();
 
-	GdFloat get_time_scale();
-	void set_time_scale(GdFloat time_scale);
+	SPX_API GdFloat get_time_scale();
+	SPX_API void set_time_scale(GdFloat time_scale);
 
-	GdInt get_max_fps();
-	void set_max_fps(GdInt fps);
+	SPX_API GdInt get_max_fps();
+	SPX_API void set_max_fps(GdInt fps);
 
-	GdString get_persistant_data_dir();
-	void set_persistant_data_dir(GdString path);
-	GdBool is_in_persistant_data_dir(GdString path);
+	SPX_API GdString get_persistant_data_dir();
+	SPX_API void set_persistant_data_dir(GdString path);
+	SPX_API GdBool is_in_persistant_data_dir(GdString path);
 };
 
 #endif // SPX_OS_MGR_H

--- a/modules/spx/spx_res_mgr.h
+++ b/modules/spx/spx_res_mgr.h
@@ -102,16 +102,16 @@ public:
 	String _to_engine_path(const String &p_path);
 
 public:
-	void create_animation(GdString p_sprite_type, GdString p_anim_name, GdString p_json_ctx, GdInt fps, GdBool is_atlas);
-	void set_load_mode(GdBool is_direct_mode);
-	GdBool get_load_mode();
-	GdRect2 get_bound_from_alpha(GdString p_path);
-	GdVec2 get_image_size(GdString p_path);
-	GdString read_all_text(GdString p_path);
-	GdBool has_file(GdString p_path);
-	void reload_texture(GdString path);
-	void free_str(GdString str);
-	void set_default_font(GdString font_path);
+	SPX_API void create_animation(GdString p_sprite_type, GdString p_anim_name, GdString p_json_ctx, GdInt fps, GdBool is_atlas);
+	SPX_API void set_load_mode(GdBool is_direct_mode);
+	SPX_API GdBool get_load_mode();
+	SPX_API GdRect2 get_bound_from_alpha(GdString p_path);
+	SPX_API GdVec2 get_image_size(GdString p_path);
+	SPX_API GdString read_all_text(GdString p_path);
+	SPX_API GdBool has_file(GdString p_path);
+	SPX_API void reload_texture(GdString path);
+	SPX_API void free_str(GdString str);
+	SPX_API void set_default_font(GdString font_path);
 };
 
 #endif // SPX_RES_MGR_H

--- a/modules/spx/spx_scene_mgr.h
+++ b/modules/spx/spx_scene_mgr.h
@@ -74,18 +74,18 @@ public:
 public:
 	virtual ~SpxSceneMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor
 
-	void change_scene_to_file(GdString path);
-	void destroy_all_sprites();
-	GdInt reload_current_scene();
-	void unload_current_scene();
+	SPX_API void change_scene_to_file(GdString path);
+	SPX_API void destroy_all_sprites();
+	SPX_API GdInt reload_current_scene();
+	SPX_API void unload_current_scene();
 
 	// create sprites
-	void clear_pure_sprites();
-	void create_pure_sprite(GdString texture_path, GdVec2 pos, GdInt zindex);
-	void destroy_pure_sprite(GdObj id);
+	SPX_API void clear_pure_sprites();
+	SPX_API void create_pure_sprite(GdString texture_path, GdVec2 pos, GdInt zindex);
+	SPX_API void destroy_pure_sprite(GdObj id);
 
-	GdObj create_render_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot);
-	GdObj create_static_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot, GdInt collider_type, GdVec2 collider_pivot, GdArray collider_params);
+	SPX_API GdObj create_render_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot);
+	SPX_API GdObj create_static_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot, GdInt collider_type, GdVec2 collider_pivot, GdArray collider_params);
 };
 
 #endif // SPX_SCENE_MGR_H

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -138,163 +138,163 @@ public:
 	void collect_sortable_sprites(Vector<ISortableSprite *> &out);
 
 public:
-	void set_dont_destroy_on_load(GdObj obj);
+	SPX_API void set_dont_destroy_on_load(GdObj obj);
 	// process
-	void set_process(GdObj obj, GdBool is_on);
-	void set_physic_process(GdObj obj, GdBool is_on);
+	SPX_API void set_process(GdObj obj, GdBool is_on);
+	SPX_API void set_physic_process(GdObj obj, GdBool is_on);
 
-	void set_type_name(GdObj obj, GdString type_name);
+	SPX_API void set_type_name(GdObj obj, GdString type_name);
 
-	void set_pivot(GdObj obj, GdVec2 pivot);
-	GdVec2 get_pivot(GdObj obj);
+	SPX_API void set_pivot(GdObj obj, GdVec2 pivot);
+	SPX_API GdVec2 get_pivot(GdObj obj);
 
 	// children
-	void set_child_position(GdObj obj, GdString path, GdVec2 pos);
-	GdVec2 get_child_position(GdObj obj, GdString path);
-	void set_child_rotation(GdObj obj, GdString path, GdFloat rot);
-	GdFloat get_child_rotation(GdObj obj, GdString path);
-	void set_child_scale(GdObj obj, GdString path, GdVec2 scale);
-	GdVec2 get_child_scale(GdObj obj, GdString path);
+	SPX_API void set_child_position(GdObj obj, GdString path, GdVec2 pos);
+	SPX_API GdVec2 get_child_position(GdObj obj, GdString path);
+	SPX_API void set_child_rotation(GdObj obj, GdString path, GdFloat rot);
+	SPX_API GdFloat get_child_rotation(GdObj obj, GdString path);
+	SPX_API void set_child_scale(GdObj obj, GdString path, GdVec2 scale);
+	SPX_API GdVec2 get_child_scale(GdObj obj, GdString path);
 
-	GdBool check_collision(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger);
-	GdBool check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger);
-	void set_debug_collision_visible(GdObj obj, GdBool visible);
-	GdBool is_debug_collision_visible(GdObj obj);
-	GdObj create_backdrop(GdString path);
-	GdObj create_sprite(GdString path, GdVec2 pos);
-	GdObj create_bare_sprite(GdVec2 pos);
-	GdObj clone_sprite(GdObj obj);
-	GdBool destroy_sprite(GdObj obj);
-	GdBool is_sprite_alive(GdObj obj);
-	void set_position(GdObj obj, GdVec2 pos);
-	GdVec2 get_position(GdObj obj);
-	void set_rotation(GdObj obj, GdFloat rot);
-	GdFloat get_rotation(GdObj obj);
-	void set_scale(GdObj obj, GdVec2 scale);
-	GdVec2 get_scale(GdObj obj);
-	void set_render_scale(GdObj obj, GdVec2 scale);
-	GdVec2 get_render_scale(GdObj obj);
-	void set_color(GdObj obj, GdColor color);
-	GdColor get_color(GdObj obj);
+	SPX_API GdBool check_collision(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger);
+	SPX_API GdBool check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger);
+	SPX_API void set_debug_collision_visible(GdObj obj, GdBool visible);
+	SPX_API GdBool is_debug_collision_visible(GdObj obj);
+	SPX_API GdObj create_backdrop(GdString path);
+	SPX_API GdObj create_sprite(GdString path, GdVec2 pos);
+	SPX_API GdObj create_bare_sprite(GdVec2 pos);
+	SPX_API GdObj clone_sprite(GdObj obj);
+	SPX_API GdBool destroy_sprite(GdObj obj);
+	SPX_API GdBool is_sprite_alive(GdObj obj);
+	SPX_API void set_position(GdObj obj, GdVec2 pos);
+	SPX_API GdVec2 get_position(GdObj obj);
+	SPX_API void set_rotation(GdObj obj, GdFloat rot);
+	SPX_API GdFloat get_rotation(GdObj obj);
+	SPX_API void set_scale(GdObj obj, GdVec2 scale);
+	SPX_API GdVec2 get_scale(GdObj obj);
+	SPX_API void set_render_scale(GdObj obj, GdVec2 scale);
+	SPX_API GdVec2 get_render_scale(GdObj obj);
+	SPX_API void set_color(GdObj obj, GdColor color);
+	SPX_API GdColor get_color(GdObj obj);
 
-	void set_material_shader(GdObj obj, GdString path);
-	GdString get_material_shader(GdObj obj);
-	void set_material_params(GdObj obj, GdString effect, GdFloat amount);
-	GdFloat get_material_params(GdObj obj, GdString effect);
+	SPX_API void set_material_shader(GdObj obj, GdString path);
+	SPX_API GdString get_material_shader(GdObj obj);
+	SPX_API void set_material_params(GdObj obj, GdString effect, GdFloat amount);
+	SPX_API GdFloat get_material_params(GdObj obj, GdString effect);
 
-	void set_material_params_vec(GdObj obj, GdString effect, GdFloat x, GdFloat y, GdFloat z, GdFloat w);
+	SPX_API void set_material_params_vec(GdObj obj, GdString effect, GdFloat x, GdFloat y, GdFloat z, GdFloat w);
 
-	void set_material_params_vec4(GdObj obj, GdString effect, GdVec4 vec4);
-	GdVec4 get_material_params_vec4(GdObj obj, GdString effect);
+	SPX_API void set_material_params_vec4(GdObj obj, GdString effect, GdVec4 vec4);
+	SPX_API GdVec4 get_material_params_vec4(GdObj obj, GdString effect);
 
-	void set_material_params_color(GdObj obj, GdString effect, GdColor color);
-	GdColor get_material_params_color(GdObj obj, GdString effect);
+	SPX_API void set_material_params_color(GdObj obj, GdString effect, GdColor color);
+	SPX_API GdColor get_material_params_color(GdObj obj, GdString effect);
 
-	void set_texture_atlas(GdObj obj, GdString path, GdRect2 rect2);
-	void set_texture(GdObj obj, GdString path);
-	void set_texture_atlas_direct(GdObj obj, GdString path, GdRect2 rect2);
-	void set_texture_direct(GdObj obj, GdString path);
+	SPX_API void set_texture_atlas(GdObj obj, GdString path, GdRect2 rect2);
+	SPX_API void set_texture(GdObj obj, GdString path);
+	SPX_API void set_texture_atlas_direct(GdObj obj, GdString path, GdRect2 rect2);
+	SPX_API void set_texture_direct(GdObj obj, GdString path);
 
-	GdString get_texture(GdObj obj);
-	void set_visible(GdObj obj, GdBool visible);
-	GdBool get_visible(GdObj obj);
-	GdInt get_z_index(GdObj obj);
-	void set_z_index(GdObj obj, GdInt z);
+	SPX_API GdString get_texture(GdObj obj);
+	SPX_API void set_visible(GdObj obj, GdBool visible);
+	SPX_API GdBool get_visible(GdObj obj);
+	SPX_API GdInt get_z_index(GdObj obj);
+	SPX_API void set_z_index(GdObj obj, GdInt z);
 
 	// animation
-	void play_anim(GdObj obj, GdString p_name, GdFloat p_speed, GdBool isLoop, GdBool p_revert);
-	void play_backwards_anim(GdObj obj, GdString p_name);
-	void pause_anim(GdObj obj);
-	void stop_anim(GdObj obj);
-	GdBool is_playing_anim(GdObj obj);
-	void set_anim(GdObj obj, GdString p_name);
-	GdString get_anim(GdObj obj);
-	void set_anim_frame(GdObj obj, GdInt p_frame);
-	GdInt get_anim_frame(GdObj obj);
-	void set_anim_speed_scale(GdObj obj, GdFloat p_speed_scale);
-	GdFloat get_anim_speed_scale(GdObj obj);
-	GdFloat get_anim_playing_speed(GdObj obj);
-	void set_anim_centered(GdObj obj, GdBool p_center);
-	GdBool is_anim_centered(GdObj obj);
-	void set_anim_offset(GdObj obj, GdVec2 p_offset);
-	GdVec2 get_anim_offset(GdObj obj);
-	void set_anim_flip_h(GdObj obj, GdBool p_flip);
-	GdBool is_anim_flipped_h(GdObj obj);
-	void set_anim_flip_v(GdObj obj, GdBool p_flip);
-	GdBool is_anim_flipped_v(GdObj obj);
-	GdString get_current_anim_name(GdObj obj);
+	SPX_API void play_anim(GdObj obj, GdString p_name, GdFloat p_speed, GdBool isLoop, GdBool p_revert);
+	SPX_API void play_backwards_anim(GdObj obj, GdString p_name);
+	SPX_API void pause_anim(GdObj obj);
+	SPX_API void stop_anim(GdObj obj);
+	SPX_API GdBool is_playing_anim(GdObj obj);
+	SPX_API void set_anim(GdObj obj, GdString p_name);
+	SPX_API GdString get_anim(GdObj obj);
+	SPX_API void set_anim_frame(GdObj obj, GdInt p_frame);
+	SPX_API GdInt get_anim_frame(GdObj obj);
+	SPX_API void set_anim_speed_scale(GdObj obj, GdFloat p_speed_scale);
+	SPX_API GdFloat get_anim_speed_scale(GdObj obj);
+	SPX_API GdFloat get_anim_playing_speed(GdObj obj);
+	SPX_API void set_anim_centered(GdObj obj, GdBool p_center);
+	SPX_API GdBool is_anim_centered(GdObj obj);
+	SPX_API void set_anim_offset(GdObj obj, GdVec2 p_offset);
+	SPX_API GdVec2 get_anim_offset(GdObj obj);
+	SPX_API void set_anim_flip_h(GdObj obj, GdBool p_flip);
+	SPX_API GdBool is_anim_flipped_h(GdObj obj);
+	SPX_API void set_anim_flip_v(GdObj obj, GdBool p_flip);
+	SPX_API GdBool is_anim_flipped_v(GdObj obj);
+	SPX_API GdString get_current_anim_name(GdObj obj);
 
 	// physics
-	void set_velocity(GdObj obj, GdVec2 velocity);
-	GdVec2 get_velocity(GdObj obj);
-	GdBool is_on_floor(GdObj obj);
-	GdBool is_on_floor_only(GdObj obj);
-	GdBool is_on_wall(GdObj obj);
-	GdBool is_on_wall_only(GdObj obj);
-	GdBool is_on_ceiling(GdObj obj);
-	GdBool is_on_ceiling_only(GdObj obj);
-	GdVec2 get_last_motion(GdObj obj);
-	GdVec2 get_position_delta(GdObj obj);
-	GdVec2 get_floor_normal(GdObj obj);
-	GdVec2 get_wall_normal(GdObj obj);
-	GdVec2 get_real_velocity(GdObj obj);
-	void move_and_slide(GdObj obj);
+	SPX_API void set_velocity(GdObj obj, GdVec2 velocity);
+	SPX_API GdVec2 get_velocity(GdObj obj);
+	SPX_API GdBool is_on_floor(GdObj obj);
+	SPX_API GdBool is_on_floor_only(GdObj obj);
+	SPX_API GdBool is_on_wall(GdObj obj);
+	SPX_API GdBool is_on_wall_only(GdObj obj);
+	SPX_API GdBool is_on_ceiling(GdObj obj);
+	SPX_API GdBool is_on_ceiling_only(GdObj obj);
+	SPX_API GdVec2 get_last_motion(GdObj obj);
+	SPX_API GdVec2 get_position_delta(GdObj obj);
+	SPX_API GdVec2 get_floor_normal(GdObj obj);
+	SPX_API GdVec2 get_wall_normal(GdObj obj);
+	SPX_API GdVec2 get_real_velocity(GdObj obj);
+	SPX_API void move_and_slide(GdObj obj);
 
-	void set_gravity(GdObj obj, GdFloat gravity);
-	GdFloat get_gravity(GdObj obj);
-	void set_mass(GdObj obj, GdFloat mass);
-	GdFloat get_mass(GdObj obj);
-	void add_force(GdObj obj, GdVec2 force);
-	void add_impulse(GdObj obj, GdVec2 impulse);
+	SPX_API void set_gravity(GdObj obj, GdFloat gravity);
+	SPX_API GdFloat get_gravity(GdObj obj);
+	SPX_API void set_mass(GdObj obj, GdFloat mass);
+	SPX_API GdFloat get_mass(GdObj obj);
+	SPX_API void add_force(GdObj obj, GdVec2 force);
+	SPX_API void add_impulse(GdObj obj, GdVec2 impulse);
 
-	void set_physics_mode(GdObj obj, GdInt mode);
-	GdInt get_physics_mode(GdObj obj);
-	void set_use_gravity(GdObj obj, GdBool enabled);
-	GdBool is_use_gravity(GdObj obj);
-	void set_gravity_scale(GdObj obj, GdFloat scale);
-	GdFloat get_gravity_scale(GdObj obj);
-	void set_drag(GdObj obj, GdFloat drag);
-	GdFloat get_drag(GdObj obj);
-	void set_friction(GdObj obj, GdFloat friction);
-	GdFloat get_friction(GdObj obj);
+	SPX_API void set_physics_mode(GdObj obj, GdInt mode);
+	SPX_API GdInt get_physics_mode(GdObj obj);
+	SPX_API void set_use_gravity(GdObj obj, GdBool enabled);
+	SPX_API GdBool is_use_gravity(GdObj obj);
+	SPX_API void set_gravity_scale(GdObj obj, GdFloat scale);
+	SPX_API GdFloat get_gravity_scale(GdObj obj);
+	SPX_API void set_drag(GdObj obj, GdFloat drag);
+	SPX_API GdFloat get_drag(GdObj obj);
+	SPX_API void set_friction(GdObj obj, GdFloat friction);
+	SPX_API GdFloat get_friction(GdObj obj);
 
-	void set_collision_layer(GdObj obj, GdInt layer);
-	GdInt get_collision_layer(GdObj obj);
-	void set_collision_mask(GdObj obj, GdInt mask);
-	GdInt get_collision_mask(GdObj obj);
+	SPX_API void set_collision_layer(GdObj obj, GdInt layer);
+	SPX_API GdInt get_collision_layer(GdObj obj);
+	SPX_API void set_collision_mask(GdObj obj, GdInt mask);
+	SPX_API GdInt get_collision_mask(GdObj obj);
 
-	void set_trigger_layer(GdObj obj, GdInt layer);
-	GdInt get_trigger_layer(GdObj obj);
-	void set_trigger_mask(GdObj obj, GdInt mask);
-	GdInt get_trigger_mask(GdObj obj);
+	SPX_API void set_trigger_layer(GdObj obj, GdInt layer);
+	SPX_API GdInt get_trigger_layer(GdObj obj);
+	SPX_API void set_trigger_mask(GdObj obj, GdInt mask);
+	SPX_API GdInt get_trigger_mask(GdObj obj);
 
-	void set_collider_rect(GdObj obj, GdVec2 center, GdVec2 size);
-	void set_collider_circle(GdObj obj, GdVec2 center, GdFloat radius);
-	void set_collider_capsule(GdObj obj, GdVec2 center, GdVec2 size);
-	void set_collider_polygon(GdObj obj, GdVec2 center, GdArray points);
-	void set_collision_enabled(GdObj obj, GdBool enabled);
-	GdBool is_collision_enabled(GdObj obj);
+	SPX_API void set_collider_rect(GdObj obj, GdVec2 center, GdVec2 size);
+	SPX_API void set_collider_circle(GdObj obj, GdVec2 center, GdFloat radius);
+	SPX_API void set_collider_capsule(GdObj obj, GdVec2 center, GdVec2 size);
+	SPX_API void set_collider_polygon(GdObj obj, GdVec2 center, GdArray points);
+	SPX_API void set_collision_enabled(GdObj obj, GdBool enabled);
+	SPX_API GdBool is_collision_enabled(GdObj obj);
 
-	void set_trigger_rect(GdObj obj, GdVec2 center, GdVec2 size);
-	void set_trigger_circle(GdObj obj, GdVec2 center, GdFloat radius);
-	void set_trigger_capsule(GdObj obj, GdVec2 center, GdVec2 size);
-	void set_trigger_polygon(GdObj obj, GdVec2 center, GdArray points);
-	void set_trigger_enabled(GdObj obj, GdBool trigger);
-	GdBool is_trigger_enabled(GdObj obj);
+	SPX_API void set_trigger_rect(GdObj obj, GdVec2 center, GdVec2 size);
+	SPX_API void set_trigger_circle(GdObj obj, GdVec2 center, GdFloat radius);
+	SPX_API void set_trigger_capsule(GdObj obj, GdVec2 center, GdVec2 size);
+	SPX_API void set_trigger_polygon(GdObj obj, GdVec2 center, GdArray points);
+	SPX_API void set_trigger_enabled(GdObj obj, GdBool trigger);
+	SPX_API GdBool is_trigger_enabled(GdObj obj);
 
 	// misc
-	GdBool check_collision_by_color(GdObj obj, GdColor color, GdFloat color_threshold, GdFloat alpha_threshold);
-	GdBool check_collision_by_alpha(GdObj obj, GdFloat alpha_threshold);
-	GdBool check_collision_with_sprite(GdObj obj, GdObj obj_b, GdFloat alpha_threshold, GdBool use_pixel_perfect);
+	SPX_API GdBool check_collision_by_color(GdObj obj, GdColor color, GdFloat color_threshold, GdFloat alpha_threshold);
+	SPX_API GdBool check_collision_by_alpha(GdObj obj, GdFloat alpha_threshold);
+	SPX_API GdBool check_collision_with_sprite(GdObj obj, GdObj obj_b, GdFloat alpha_threshold, GdBool use_pixel_perfect);
 
 	// pixel collision sampling configuration
-	void set_pixel_collision_sampling_step(GdInt step);
-	GdInt get_pixel_collision_sampling_step();
+	SPX_API void set_pixel_collision_sampling_step(GdInt step);
+	SPX_API GdInt get_pixel_collision_sampling_step();
 
 	// batch sync
-	void batch_update_transforms(const float *buffer_data, int len);
-	void batch_update_visuals(const float *buffer_data, int len);
-	GdArray batch_retrieve_positions(GdArray objs);
+	SPX_API void batch_update_transforms(const float *buffer_data, int len);
+	SPX_API void batch_update_visuals(const float *buffer_data, int len);
+	SPX_API GdArray batch_retrieve_positions(GdArray objs);
 };
 
 #endif // SPX_SPRITE_MGR_H

--- a/modules/spx/spx_tilemap_mgr.h
+++ b/modules/spx/spx_tilemap_mgr.h
@@ -47,23 +47,23 @@ private:
 	SpxDrawTiles *draw_tiles = nullptr;
 
 public:
-	void open_draw_tiles_with_size(GdInt tile_size);
-	void open_draw_tiles();
-	void set_layer_index(GdInt index);
-	void set_tile(GdString texture_path, GdBool with_collision);
-	void set_tile_with_collision_info(GdString texture_path, GdArray collision_points);
-	void set_layer_offset(GdInt index, GdVec2 offset);
-	GdVec2 get_layer_offset(GdInt index);
-	void place_tiles(GdArray positions, GdString texture_path);
-	void place_tiles_with_layer(GdArray positions, GdString texture_path, GdInt layer_index);
-	void place_tile(GdVec2 pos, GdString texture_path);
-	void place_tile_with_layer(GdVec2 pos, GdString texture_path, GdInt layer_index);
-	void erase_tile(GdVec2 pos);
-	void erase_tile_with_layer(GdVec2 pos, GdInt layer_index);
-	GdString get_tile(GdVec2 pos);
-	GdString get_tile_with_layer(GdVec2 pos, GdInt layer_index);
-	void close_draw_tiles();
-	void exit_tilemap_editor_mode();
+	SPX_API void open_draw_tiles_with_size(GdInt tile_size);
+	SPX_API void open_draw_tiles();
+	SPX_API void set_layer_index(GdInt index);
+	SPX_API void set_tile(GdString texture_path, GdBool with_collision);
+	SPX_API void set_tile_with_collision_info(GdString texture_path, GdArray collision_points);
+	SPX_API void set_layer_offset(GdInt index, GdVec2 offset);
+	SPX_API GdVec2 get_layer_offset(GdInt index);
+	SPX_API void place_tiles(GdArray positions, GdString texture_path);
+	SPX_API void place_tiles_with_layer(GdArray positions, GdString texture_path, GdInt layer_index);
+	SPX_API void place_tile(GdVec2 pos, GdString texture_path);
+	SPX_API void place_tile_with_layer(GdVec2 pos, GdString texture_path, GdInt layer_index);
+	SPX_API void erase_tile(GdVec2 pos);
+	SPX_API void erase_tile_with_layer(GdVec2 pos, GdInt layer_index);
+	SPX_API GdString get_tile(GdVec2 pos);
+	SPX_API GdString get_tile_with_layer(GdVec2 pos, GdInt layer_index);
+	SPX_API void close_draw_tiles();
+	SPX_API void exit_tilemap_editor_mode();
 
 	template <typename Func>
 	void with_draw_tiles(Func f, const String error_msg = "The draw tiles node is null, first open it!!!") {

--- a/modules/spx/spx_tilemapparser_mgr.h
+++ b/modules/spx/spx_tilemapparser_mgr.h
@@ -80,13 +80,13 @@ public:
 
 public:
 	// Main API
-	void load_tilemap(GdString json_path);
-	void unload_tilemap(GdString name);
-	void destroy_all_tilemaps();
+	SPX_API void load_tilemap(GdString json_path);
+	SPX_API void unload_tilemap(GdString name);
+	SPX_API void destroy_all_tilemaps();
 
 	// Query API
-	GdBool has_tilemap(GdString name);
-	GdInt get_tilemap_layer_count(GdString name);
+	SPX_API GdBool has_tilemap(GdString name);
+	SPX_API GdInt get_tilemap_layer_count(GdString name);
 };
 
 #endif // SPX_TILEMAP_PARSER_MGR_H

--- a/modules/spx/spx_ui_mgr.h
+++ b/modules/spx/spx_ui_mgr.h
@@ -61,52 +61,52 @@ public:
 	void on_click(ISpxUi *node);
 
 public:
-	GdObj bind_node(GdObj obj, GdString rel_path);
+	SPX_API GdObj bind_node(GdObj obj, GdString rel_path);
 
-	GdObj create_node(GdString path);
-	GdObj create_button(GdString path, GdString text);
-	GdObj create_label(GdString path, GdString text);
-	GdObj create_image(GdString path);
-	GdObj create_toggle(GdString path, GdBool value);
-	GdObj create_slider(GdString path, GdFloat value);
-	GdObj create_input(GdString path, GdString text);
-	GdBool destroy_node(GdObj obj);
+	SPX_API GdObj create_node(GdString path);
+	SPX_API GdObj create_button(GdString path, GdString text);
+	SPX_API GdObj create_label(GdString path, GdString text);
+	SPX_API GdObj create_image(GdString path);
+	SPX_API GdObj create_toggle(GdString path, GdBool value);
+	SPX_API GdObj create_slider(GdString path, GdFloat value);
+	SPX_API GdObj create_input(GdString path, GdString text);
+	SPX_API GdBool destroy_node(GdObj obj);
 
-	GdInt get_type(GdObj obj);
-	void set_text(GdObj obj, GdString text);
-	GdString get_text(GdObj obj);
-	void set_texture(GdObj obj, GdString path);
-	GdString get_texture(GdObj obj);
-	void set_color(GdObj obj, GdColor color);
-	GdColor get_color(GdObj obj);
-	void set_font_size(GdObj obj, GdInt size);
-	GdInt get_font_size(GdObj obj);
-	void set_visible(GdObj obj, GdBool visible);
-	GdBool get_visible(GdObj obj);
-	void set_interactable(GdObj obj, GdBool interactable);
-	GdBool get_interactable(GdObj obj);
-	void set_rect(GdObj obj, GdRect2 rect);
-	GdRect2 get_rect(GdObj obj);
+	SPX_API GdInt get_type(GdObj obj);
+	SPX_API void set_text(GdObj obj, GdString text);
+	SPX_API GdString get_text(GdObj obj);
+	SPX_API void set_texture(GdObj obj, GdString path);
+	SPX_API GdString get_texture(GdObj obj);
+	SPX_API void set_color(GdObj obj, GdColor color);
+	SPX_API GdColor get_color(GdObj obj);
+	SPX_API void set_font_size(GdObj obj, GdInt size);
+	SPX_API GdInt get_font_size(GdObj obj);
+	SPX_API void set_visible(GdObj obj, GdBool visible);
+	SPX_API GdBool get_visible(GdObj obj);
+	SPX_API void set_interactable(GdObj obj, GdBool interactable);
+	SPX_API GdBool get_interactable(GdObj obj);
+	SPX_API void set_rect(GdObj obj, GdRect2 rect);
+	SPX_API GdRect2 get_rect(GdObj obj);
 
-	GdInt get_layout_direction(GdObj obj);
-	void set_layout_direction(GdObj obj, GdInt value);
-	GdInt get_layout_mode(GdObj obj);
-	void set_layout_mode(GdObj obj, GdInt value);
-	GdInt get_anchors_preset(GdObj obj);
-	void set_anchors_preset(GdObj obj, GdInt value);
-	GdVec2 get_scale(GdObj obj);
-	void set_scale(GdObj obj, GdVec2 value);
-	GdVec2 get_position(GdObj obj);
-	void set_position(GdObj obj, GdVec2 value);
-	GdVec2 get_size(GdObj obj);
-	void set_size(GdObj obj, GdVec2 value);
-	GdVec2 get_global_position(GdObj obj);
-	void set_global_position(GdObj obj, GdVec2 value);
-	GdFloat get_rotation(GdObj obj);
-	void set_rotation(GdObj obj, GdFloat value);
+	SPX_API GdInt get_layout_direction(GdObj obj);
+	SPX_API void set_layout_direction(GdObj obj, GdInt value);
+	SPX_API GdInt get_layout_mode(GdObj obj);
+	SPX_API void set_layout_mode(GdObj obj, GdInt value);
+	SPX_API GdInt get_anchors_preset(GdObj obj);
+	SPX_API void set_anchors_preset(GdObj obj, GdInt value);
+	SPX_API GdVec2 get_scale(GdObj obj);
+	SPX_API void set_scale(GdObj obj, GdVec2 value);
+	SPX_API GdVec2 get_position(GdObj obj);
+	SPX_API void set_position(GdObj obj, GdVec2 value);
+	SPX_API GdVec2 get_size(GdObj obj);
+	SPX_API void set_size(GdObj obj, GdVec2 value);
+	SPX_API GdVec2 get_global_position(GdObj obj);
+	SPX_API void set_global_position(GdObj obj, GdVec2 value);
+	SPX_API GdFloat get_rotation(GdObj obj);
+	SPX_API void set_rotation(GdObj obj, GdFloat value);
 
-	GdBool get_flip(GdObj obj, GdBool horizontal);
-	void set_flip(GdObj obj, GdBool horizontal, GdBool is_flip);
+	SPX_API GdBool get_flip(GdObj obj, GdBool horizontal);
+	SPX_API void set_flip(GdObj obj, GdBool horizontal, GdBool is_flip);
 };
 
 #endif // SPX_UI_MGR_H


### PR DESCRIPTION
## Summary

- Add `SPX_API` / `SPX_BIND` no-op macros for SPX ABI annotations.
- Mark all currently exported SPX manager methods with `SPX_API`.
- Leave lifecycle overrides and internal helper methods unmarked, so they no longer become ABI by accident.

## Notes

This pairs with the SPX codegen PR that only exports methods carrying explicit ABI annotations.

## Verification

- Validated through the SPX repo with `make generate-bindings`
- Confirmed generated `gdextension_spx_ext.h` copies match

