### PR TITLE
Fix macOS window sizing with content scale

### DIFF
--- a/modules/spx/spx_platform_mgr.cpp
+++ b/modules/spx/spx_platform_mgr.cpp
@@ -37,12 +37,25 @@
 #include "spx_camera_mgr.h"
 #include "spx_engine.h"
 
+#ifdef MACOS_ENABLED
+static Size2i _spx_scale_window_size_for_macos(const Size2i &p_size) {
+	const float scale = DisplayServer::get_singleton()->screen_get_max_scale();
+	return Size2i((Vector2(p_size) * scale).round());
+}
+
+static Size2i _spx_unscale_window_size_for_macos(const Size2i &p_size) {
+	const float scale = DisplayServer::get_singleton()->screen_get_max_scale();
+	return Size2i((Vector2(p_size) / scale).round());
+}
+#endif
+
 void SpxPlatformMgr::on_awake() {
 	SpxBaseMgr::on_awake();
 	persistant_data_dir = ::OS::get_singleton()->get_user_data_dir();
 }
 
 void SpxPlatformMgr::on_reset(int reset_code) {
+	window_size_uses_content_scale = false;
 	set_stretch_mode(false);
 }
 
@@ -87,11 +100,29 @@ void SpxPlatformMgr::set_window_size(GdInt width, GdInt height, GdBool with_cont
 	if (with_content_scale) {
 		set_stretch_content_scale(width, height);
 	}
-	get_root()->set_size(Size2i(width, height));
+
+	window_size_uses_content_scale = with_content_scale;
+
+	Size2i window_size(width, height);
+#ifdef MACOS_ENABLED
+	if (window_size_uses_content_scale) {
+		// Godot's macOS backend normalizes window sizes by the global max display
+		// scale. SPX callers pass logical window dimensions, so convert explicitly
+		// to keep the visible window size stable on HiDPI displays.
+		window_size = _spx_scale_window_size_for_macos(window_size);
+	}
+#endif
+
+	get_root()->set_size(window_size);
 }
 
 GdVec2 SpxPlatformMgr::get_window_size() {
 	auto size = DisplayServer::get_singleton()->window_get_size_ext();
+#ifdef MACOS_ENABLED
+	if (window_size_uses_content_scale) {
+		size = _spx_unscale_window_size_for_macos(size);
+	}
+#endif
 	return GdVec2(size.x, size.y);
 }
 

--- a/modules/spx/spx_platform_mgr.h
+++ b/modules/spx/spx_platform_mgr.h
@@ -37,6 +37,7 @@
 class SpxPlatformMgr : public SpxBaseMgr {
 	SPXCLASS(SpxPlatformMgr, SpxBaseMgr)
 	String persistant_data_dir = "res://";
+	bool window_size_uses_content_scale = false;
 
 public:
 	virtual ~SpxPlatformMgr() = default; // Added virtual destructor to fix -Werror=non-virtual-dtor


### PR DESCRIPTION
Title
Fix macOS window sizing with content scale

Summary
This change fixes window sizing on macOS when `with_content_scale` is enabled in `SpxPlatformMgr::set_window_size()`.

Background
Godot's macOS backend normalizes `window_set_size()` using the maximum display scale. SPX passes logical content dimensions here, which causes the visible window size to shrink on HiDPI displays when content scaling is enabled.

Changes
- Keep using the logical width/height for `set_stretch_content_scale()`
- Add a macOS-only size compensation path before `get_root()->set_size()`
- Multiply the requested window size by `DisplayServer::screen_get_max_scale()` when `with_content_scale` is true

Expected Result
On macOS HiDPI displays, enabling content scale no longer makes the visible window smaller than the requested logical size.

Testing
- Not run locally
- Recommended manual verification on macOS Retina / HiDPI display:
  - call `set_window_size(width, height, true)`
  - confirm visible window size matches expected logical dimensions
  - confirm non-macOS behavior is unchanged
