### PR TITLE
fix(spx): avoid double pivot offset for single images

### DIFF
--- a/modules/spx/spx_sprite_render.cpp
+++ b/modules/spx/spx_sprite_render.cpp
@@ -36,6 +36,7 @@
 #include "spx_camera_mgr.h"
 #include "spx_engine.h"
 #include "spx_res_mgr.h"
+#include "spx_sprite_render_util.h"
 #include "svg_mgr.h"
 
 void SpxSprite::set_render_scale(GdVec2 p_scale) {
@@ -172,7 +173,7 @@ void SpxSprite::_on_frame_changed() {
 	String current_anim = String(anim2d->get_animation());
 	int current_frame = anim2d->get_frame();
 	Vector2 frame_offset = resMgr->get_animation_frame_offset(current_anim, current_frame);
-	Vector2 final_offset = base_offset - pivot_offset + frame_offset * _render_scale;
+	Vector2 final_offset = spx_compute_anim_offset(is_single_image_mode, base_offset, pivot_offset, frame_offset, _render_scale);
 	anim2d->set_offset(final_offset);
 }
 

--- a/modules/spx/spx_sprite_render_util.h
+++ b/modules/spx/spx_sprite_render_util.h
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  spx_sprite_render_util.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SPX_SPRITE_RENDER_UTIL_H
+#define SPX_SPRITE_RENDER_UTIL_H
+
+#include "core/math/vector2.h"
+
+// Scratch costume switching updates the node position with the costume center
+// offset already applied. In single-image mode we must not subtract the pivot a
+// second time through AnimatedSprite2D's per-frame offset path.
+static inline Vector2 spx_compute_anim_offset(bool p_is_single_image_mode, const Vector2 &p_base_offset, const Vector2 &p_pivot_offset, const Vector2 &p_frame_offset, const Vector2 &p_render_scale) {
+	Vector2 final_offset = p_base_offset + (p_frame_offset * p_render_scale);
+	if (!p_is_single_image_mode) {
+		final_offset -= p_pivot_offset;
+	}
+	return final_offset;
+}
+
+#endif // SPX_SPRITE_RENDER_UTIL_H


### PR DESCRIPTION
Fixes [10133937/ElectricityInsideUs.sb2]in https://github.com/goplus/sb2xbp/issues/325