### PR TITLE
refactor(font): add explicit svg font face registration api

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -398,6 +398,9 @@ static void gdextension_spx_res_free_str(GdString str) {
 static void gdextension_spx_res_set_default_font(GdString font_path) {
 	resMgr->set_default_font(font_path);
 }
+static void gdextension_spx_res_register_svg_font_face(GdString font_path, GdString family) {
+	resMgr->register_svg_font_face(font_path, family);
+}
 static void gdextension_spx_scene_change_scene_to_file(GdString path) {
 	sceneMgr->change_scene_to_file(path);
 }
@@ -1123,6 +1126,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_reload_texture);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_free_str);
 	REGISTER_SPX_INTERFACE_FUNC(spx_res_set_default_font);
+	REGISTER_SPX_INTERFACE_FUNC(spx_res_register_svg_font_face);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_change_scene_to_file);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_destroy_all_sprites);
 	REGISTER_SPX_INTERFACE_FUNC(spx_scene_reload_current_scene);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -339,6 +339,7 @@ typedef void (*GDExtensionSpxResHasFile)(GdString p_path, GdBool *ret_value);
 typedef void (*GDExtensionSpxResReloadTexture)(GdString path);
 typedef void (*GDExtensionSpxResFreeStr)(GdString str);
 typedef void (*GDExtensionSpxResSetDefaultFont)(GdString font_path);
+typedef void (*GDExtensionSpxResRegisterSvgFontFace)(GdString font_path, GdString family);
 // SpxScene
 typedef void (*GDExtensionSpxSceneChangeSceneToFile)(GdString path);
 typedef void (*GDExtensionSpxSceneDestroyAllSprites)();

--- a/modules/spx/spx_res_mgr.cpp
+++ b/modules/spx/spx_res_mgr.cpp
@@ -59,34 +59,22 @@
 #include "modules/svg/svg_utils.h"
 #endif
 
-struct SpxFontLoadOptions {
-	String resource_path;
-	String svg_family;
-	bool register_only = false;
-};
-
-static SpxFontLoadOptions _parse_font_load_options(const String &p_font_path) {
-	SpxFontLoadOptions options;
-	int fragment_index = p_font_path.find("#");
-	if (fragment_index < 0) {
-		options.resource_path = p_font_path;
-		return options;
+static bool _load_font_data_from_path(const String &p_path, const String &p_engine_path, Vector<uint8_t> &r_font_data) {
+	Ref<FontFile> raw_font = ResourceLoader::load(p_path);
+	if (!raw_font.is_null()) {
+		r_font_data = raw_font->get_data();
+		return true;
 	}
 
-	options.resource_path = p_font_path.substr(0, fragment_index);
-	String fragment = p_font_path.substr(fragment_index + 1, -1);
-	Vector<String> params = fragment.split("&", false);
-	for (int i = 0; i < params.size(); i++) {
-		const String &param = params[i];
-		if (param == "spx-register-only=1") {
-			options.register_only = true;
-			continue;
-		}
-		if (param.begins_with("spx-family=")) {
-			options.svg_family = param.get_slice("=", 1);
-		}
+	Ref<FileAccess> file = FileAccess::open(p_engine_path, FileAccess::READ);
+	if (file.is_null()) {
+		ERR_PRINT("Can not open font file: " + p_path + " engine_path= " + p_engine_path);
+		return false;
 	}
-	return options;
+
+	r_font_data.resize(file->get_length());
+	file->get_buffer(r_font_data.ptrw(), r_font_data.size());
+	return true;
 }
 
 void SpxResMgr::on_awake() {
@@ -526,38 +514,21 @@ GdBool SpxResMgr::has_file(GdString p_path) {
 }
 
 void SpxResMgr::set_default_font(GdString font_path) {
-	SpxFontLoadOptions options = _parse_font_load_options(SpxStr(font_path));
-	String path = options.resource_path;
+	String path = SpxStr(font_path);
 	if (path.is_empty()) {
 		ERR_PRINT("Can not open empty font path.");
 		return;
 	}
 	Vector<uint8_t> font_data;
-	Ref<FontFile> rawFont = ResourceLoader::load(path);
-	if (!rawFont.is_null()) {
-		font_data = rawFont->get_data();
-	} else {
-		String engine_path = _to_engine_path(path);
-		Ref<FileAccess> f = FileAccess::open(engine_path, FileAccess::READ);
-		if (f.is_null()) {
-			ERR_PRINT("Can not open font file: " + path + " engine_path= " + engine_path);
-			return;
-		}
-		font_data.resize(f->get_length());
-		f->get_buffer(font_data.ptrw(), font_data.size());
-	}
-	// update svg
-#ifdef MODULE_SVG_ENABLED
-	if (!options.svg_family.is_empty()) {
-		SVGUtils::add_font_face(options.svg_family, font_data.ptrw(), (int)font_data.size());
-	}
-	if (!options.register_only) {
-		SVGUtils::set_default_font(font_data.ptrw(), (int)font_data.size());
-	}
-#endif
-	if (options.register_only) {
+	String engine_path = _to_engine_path(path);
+	if (!_load_font_data_from_path(path, engine_path, font_data)) {
 		return;
 	}
+
+	// update svg
+#ifdef MODULE_SVG_ENABLED
+	SVGUtils::set_default_font(font_data.ptrw(), (int)font_data.size());
+#endif
 
 	// update theme
 	Ref<FontFile> font;
@@ -573,6 +544,33 @@ void SpxResMgr::set_default_font(GdString font_path) {
 	font->set_fixed_size(0);
 	font->set_allow_system_fallback(true);
 	ThemeDB::get_singleton()->set_default_font(font);
+}
+
+void SpxResMgr::register_svg_font_face(GdString font_path, GdString family) {
+#ifdef MODULE_SVG_ENABLED
+	String path = SpxStr(font_path);
+	if (path.is_empty()) {
+		ERR_PRINT("Can not open empty font path.");
+		return;
+	}
+
+	String svg_family = SpxStr(family);
+	if (svg_family.is_empty()) {
+		ERR_PRINT("Can not register empty SVG font family.");
+		return;
+	}
+
+	Vector<uint8_t> font_data;
+	String engine_path = _to_engine_path(path);
+	if (!_load_font_data_from_path(path, engine_path, font_data)) {
+		return;
+	}
+
+	SVGUtils::add_font_face(svg_family, font_data.ptrw(), (int)font_data.size());
+#else
+	(void)font_path;
+	(void)family;
+#endif
 }
 
 Vector2 SpxResMgr::get_animation_frame_offset(String anim_key, int frame_index) {

--- a/modules/spx/spx_res_mgr.cpp
+++ b/modules/spx/spx_res_mgr.cpp
@@ -47,6 +47,8 @@
 #include "scene/theme/default_theme.h"
 #include "scene/theme/theme_db.h"
 
+#include <limits>
+
 #include "spx_engine.h"
 #include "spx_platform_mgr.h"
 #include "svg_mgr.h"
@@ -63,6 +65,10 @@ static bool _load_font_data_from_path(const String &p_path, const String &p_engi
 	Ref<FontFile> raw_font = ResourceLoader::load(p_path);
 	if (!raw_font.is_null()) {
 		r_font_data = raw_font->get_data();
+		if (r_font_data.is_empty()) {
+			ERR_PRINT("Loaded font resource has no data: " + p_path);
+			return false;
+		}
 		return true;
 	}
 
@@ -72,8 +78,23 @@ static bool _load_font_data_from_path(const String &p_path, const String &p_engi
 		return false;
 	}
 
-	r_font_data.resize(file->get_length());
-	file->get_buffer(r_font_data.ptrw(), r_font_data.size());
+	uint64_t font_size = file->get_length();
+	if (font_size == 0) {
+		ERR_PRINT("Font file is empty: " + p_path + " engine_path= " + p_engine_path);
+		return false;
+	}
+	if (font_size > uint64_t(std::numeric_limits<int>::max())) {
+		ERR_PRINT("Font file is too large: " + p_path + " engine_path= " + p_engine_path);
+		return false;
+	}
+
+	r_font_data.resize((int)font_size);
+	uint64_t read_bytes = file->get_buffer(r_font_data.ptrw(), font_size);
+	if (read_bytes != font_size) {
+		ERR_PRINT("Can not read full font file: " + p_path + " engine_path= " + p_engine_path);
+		r_font_data.resize(0);
+		return false;
+	}
 	return true;
 }
 

--- a/modules/spx/spx_res_mgr.h
+++ b/modules/spx/spx_res_mgr.h
@@ -112,6 +112,7 @@ public:
 	SPX_API void reload_texture(GdString path);
 	SPX_API void free_str(GdString str);
 	SPX_API void set_default_font(GdString font_path);
+	SPX_API void register_svg_font_face(GdString font_path, GdString family);
 };
 
 #endif // SPX_RES_MGR_H

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -532,6 +532,10 @@ void gdspx_res_set_default_font(GdString *font_path) {
 	 resMgr->set_default_font(*font_path);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_res_register_svg_font_face(GdString *font_path, GdString *family) {
+	 resMgr->register_svg_font_face(*font_path, *family);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_scene_change_scene_to_file(GdString *path) {
 	 sceneMgr->change_scene_to_file(*path);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -6,114 +6,6 @@
 //   "gdspx.js.tmpl" so they can be included in the generated
 //   code.
 //----------------------------------------------------------------------------*/
-const SPX_DEFAULT_FONT_RESOURCE_PATH = "res://engine/fonts/CnFont.ttf";
-const SPX_SCRATCH_FONT_RESOURCE_ROOT = "res://engine/fonts/scratch/";
-const SPX_SCRATCH_PACKAGED_FONT_DEFS = [
-	{ family: "Sans Serif", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "NotoSans-Medium.ttf" },
-	{ family: "Serif", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "SourceSerifPro-Regular.otf" },
-	{ family: "Handwriting", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "handlee-regular.ttf" },
-	{ family: "Marker", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Knewave.ttf" },
-	{ family: "Curly", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Griffy-Regular.ttf" },
-	{ family: "Pixel", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Grand9K-Pixel.ttf" },
-	{ family: "Scratch", path: SPX_SCRATCH_FONT_RESOURCE_ROOT + "Scratch.ttf" },
-];
-const SPX_SCRATCH_CJK_FONT_STACKS = [
-	{ label: "中文", stack: '"Microsoft YaHei", "微软雅黑", STXihei, "华文细黑"' },
-	{ label: "日本語", stack: '"ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic"' },
-	{ label: "한국어", stack: "Malgun Gothic" },
-];
-const SPX_SCRATCH_FONT_FACE_STATE = globalThis.__spxScratchFontFaceState || (globalThis.__spxScratchFontFaceState = {
-	registered: false,
-	moduleRef: null,
-});
-
-function spxNormalizeFontRequestName(value) {
-	return String(value || "")
-		.toLowerCase()
-		.replace(/["',]/g, "")
-		.replace(/[\s_-]+/g, "")
-		.trim();
-}
-
-const SPX_SCRATCH_FONT_ALIAS_MAP = (function () {
-	var _map = Object.create(null);
-	function _registerAlias(alias, resolvedPath, svgFamily) {
-		var _key = spxNormalizeFontRequestName(alias);
-		if (_key === "") {
-			return;
-		}
-		_map[_key] = {
-			resolvedPath: resolvedPath,
-			svgFamily: svgFamily || "",
-		};
-	}
-
-	for (var _i = 0; _i < SPX_SCRATCH_PACKAGED_FONT_DEFS.length; _i++) {
-		var _fontDef = SPX_SCRATCH_PACKAGED_FONT_DEFS[_i];
-		_registerAlias(_fontDef.family, _fontDef.path, _fontDef.family);
-		_registerAlias(_fontDef.path, _fontDef.path, _fontDef.family);
-	}
-
-	for (var _j = 0; _j < SPX_SCRATCH_CJK_FONT_STACKS.length; _j++) {
-		var _cjkDef = SPX_SCRATCH_CJK_FONT_STACKS[_j];
-		_registerAlias(_cjkDef.label, SPX_DEFAULT_FONT_RESOURCE_PATH, "");
-		_registerAlias(_cjkDef.stack, SPX_DEFAULT_FONT_RESOURCE_PATH, "");
-	}
-
-	return _map;
-})();
-
-function spxBuildManagedFontPath(fontPath, options) {
-	var _metadata = [];
-	if (options != null && options.family) {
-		_metadata.push("spx-family=" + String(options.family));
-	}
-	if (options != null && options.registerOnly) {
-		_metadata.push("spx-register-only=1");
-	}
-	if (_metadata.length === 0) {
-		return String(fontPath || "");
-	}
-	return String(fontPath || "") + "#" + _metadata.join("&");
-}
-
-function spxResolveFontRequest(fontPath) {
-	var _requestedPath = String(fontPath || "");
-	var _aliasKey = spxNormalizeFontRequestName(_requestedPath);
-	var _matched = _aliasKey === "" ? null : SPX_SCRATCH_FONT_ALIAS_MAP[_aliasKey];
-	if (_matched != null) {
-		return {
-			requestedPath: _requestedPath,
-			resolvedPath: _matched.resolvedPath,
-			svgFamily: _matched.svgFamily,
-		};
-	}
-	return {
-		requestedPath: _requestedPath,
-		resolvedPath: _requestedPath,
-		svgFamily: "",
-	};
-}
-
-function spxEnsureScratchFontFacesRegistered(runtimeModule, registerFontFace) {
-	var _state = SPX_SCRATCH_FONT_FACE_STATE;
-	if (_state.moduleRef !== runtimeModule) {
-		_state.registered = false;
-		_state.moduleRef = runtimeModule;
-	}
-	if (_state.registered || typeof registerFontFace !== "function") {
-		return;
-	}
-	for (var _i = 0; _i < SPX_SCRATCH_PACKAGED_FONT_DEFS.length; _i++) {
-		var _fontDef = SPX_SCRATCH_PACKAGED_FONT_DEFS[_i];
-		registerFontFace(spxBuildManagedFontPath(_fontDef.path, {
-			family: _fontDef.family,
-			registerOnly: true,
-		}));
-	}
-	_state.registered = true;
-}
-
 class GdspxFuncs {
 constructor() {
 	this._inputMousePosScratch = null;
@@ -152,12 +44,6 @@ _readGdIntLike(ptr, scratch) {
 	scratch.low = _u32[_word];
 	scratch.high = _u32[_word + 1];
 	return scratch;
-}
-
-_invokeResSetDefaultFont(gdFuncPtr, fontPath) {
-	var _arg0 = ToGdString(fontPath);
-	gdFuncPtr(_arg0);
-	FreeGdString(_arg0);
 }
 gdspx_audio_stop_all() {
 	var _gdFuncPtr = Module._gdspx_audio_stop_all; 
@@ -1232,14 +1118,20 @@ gdspx_res_free_str(str) {
 }
 gdspx_res_set_default_font(font_path) {
 	var _gdFuncPtr = Module._gdspx_res_set_default_font; 
-	var _module = Module;
-	var _fontRequest = spxResolveFontRequest(font_path);
-	spxEnsureScratchFontFacesRegistered(_module, function (managedFontPath) {
-		this._invokeResSetDefaultFont(_gdFuncPtr, managedFontPath);
-	}.bind(this));
-	this._invokeResSetDefaultFont(_gdFuncPtr, spxBuildManagedFontPath(_fontRequest.resolvedPath, {
-		family: _fontRequest.svgFamily,
-	}));
+	
+	var _arg0 = ToGdString(font_path);
+	_gdFuncPtr(_arg0);
+	FreeGdString(_arg0); 
+
+}
+gdspx_res_register_svg_font_face(font_path,family) {
+	var _gdFuncPtr = Module._gdspx_res_register_svg_font_face; 
+	
+	var _arg0 = ToGdString(font_path);
+	var _arg1 = ToGdString(family);
+	_gdFuncPtr(_arg0, _arg1);
+	FreeGdString(_arg0); 
+	FreeGdString(_arg1); 
 
 }
 gdspx_scene_change_scene_to_file(path) {


### PR DESCRIPTION
## Summary

- add an explicit `register_svg_font_face(font_path, family)` API on `SpxResMgr`
- keep `set_default_font(font_path)` focused on updating the default SVG/theme font only
- remove the old font metadata parsing path from the engine side
- regenerate the web/native glue so the new API is exposed consistently

## Why

Previously Scratch SVG font registration depended on encoding extra metadata into the font path string.
This change replaces that with an explicit engine API, which makes the contract clearer and avoids
path-string parsing in the runtime.

## Testing

- verified the paired SPX repo can regenerate bindings successfully with `make generate-bindings`
- verified the paired SPX repo passes `go test ./...`