### PR TITLE
feat: add audio playback restart API

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -101,6 +101,9 @@ static void gdextension_spx_audio_resume(GdInt aid) {
 static void gdextension_spx_audio_stop(GdInt aid) {
 	audioMgr->stop(aid);
 }
+static void gdextension_spx_audio_restart(GdInt aid, GdBool *ret_val) {
+	*ret_val = audioMgr->restart(aid);
+}
 static void gdextension_spx_audio_set_loop(GdInt aid, GdBool loop) {
 	audioMgr->set_loop(aid, loop);
 }
@@ -1027,6 +1030,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_pause);
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_resume);
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_stop);
+	REGISTER_SPX_INTERFACE_FUNC(spx_audio_restart);
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_set_loop);
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_get_loop);
 	REGISTER_SPX_INTERFACE_FUNC(spx_audio_get_timer);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -231,6 +231,7 @@ typedef void (*GDExtensionSpxAudioPlay)(GdObj obj, GdString path, GdInt *ret_val
 typedef void (*GDExtensionSpxAudioPause)(GdInt aid);
 typedef void (*GDExtensionSpxAudioResume)(GdInt aid);
 typedef void (*GDExtensionSpxAudioStop)(GdInt aid);
+typedef void (*GDExtensionSpxAudioRestart)(GdInt aid, GdBool *ret_value);
 typedef void (*GDExtensionSpxAudioSetLoop)(GdInt aid, GdBool loop);
 typedef void (*GDExtensionSpxAudioGetLoop)(GdInt aid, GdBool *ret_value);
 typedef void (*GDExtensionSpxAudioGetTimer)(GdInt aid, GdFloat *ret_value);

--- a/modules/spx/spx_audio.cpp
+++ b/modules/spx/spx_audio.cpp
@@ -156,13 +156,11 @@ void SpxAudio::stop(GdInt aid) {
 
 GdBool SpxAudio::restart(GdInt aid) {
 	SPX_AUDIO_GUARD_RETURN(aid, __func__, false)
-	if (!audio->get_stream().is_valid()) {
+	if (audio->is_queued_for_deletion() || !audio->get_stream().is_valid()) {
 		return false;
 	}
-	audio->set_stream_paused(false);
-	audio->stop();
-	audio->play();
-	return true;
+	audio->play(0.0f);
+	return audio->is_playing();
 }
 
 void SpxAudio::set_loop(GdInt aid, GdBool loop) {

--- a/modules/spx/spx_audio.cpp
+++ b/modules/spx/spx_audio.cpp
@@ -154,6 +154,17 @@ void SpxAudio::stop(GdInt aid) {
 	audio->queue_free();
 }
 
+GdBool SpxAudio::restart(GdInt aid) {
+	SPX_AUDIO_GUARD_RETURN(aid, __func__, false)
+	if (!audio->get_stream().is_valid()) {
+		return false;
+	}
+	audio->set_stream_paused(false);
+	audio->stop();
+	audio->play();
+	return true;
+}
+
 void SpxAudio::set_loop(GdInt aid, GdBool loop) {
 	SPX_AUDIO_GUARD_VOID(aid, __func__)
 	if (loop) {

--- a/modules/spx/spx_audio.h
+++ b/modules/spx/spx_audio.h
@@ -74,6 +74,7 @@ public:
 	void pause(GdInt aid);
 	void resume(GdInt aid);
 	void stop(GdInt aid);
+	GdBool restart(GdInt aid);
 	void set_loop(GdInt aid, GdBool loop);
 	GdBool get_loop(GdInt aid);
 

--- a/modules/spx/spx_audio_mgr.cpp
+++ b/modules/spx/spx_audio_mgr.cpp
@@ -245,6 +245,18 @@ void SpxAudioMgr::stop(GdInt aid) {
 	audio->stop(aid);
 }
 
+GdBool SpxAudioMgr::restart(GdInt aid) {
+	SpxAudio *audio = nullptr;
+	{
+		MutexLock aid_lock(aid_mutex);
+		audio = _get_aid_audio(aid);
+	}
+	if (audio == nullptr) {
+		return false;
+	}
+	return audio->restart(aid);
+}
+
 void SpxAudioMgr::set_loop(GdInt aid, GdBool loop) {
 	SpxAudio *audio = nullptr;
 	{

--- a/modules/spx/spx_audio_mgr.cpp
+++ b/modules/spx/spx_audio_mgr.cpp
@@ -246,15 +246,16 @@ void SpxAudioMgr::stop(GdInt aid) {
 }
 
 GdBool SpxAudioMgr::restart(GdInt aid) {
-	SpxAudio *audio = nullptr;
-	{
-		MutexLock aid_lock(aid_mutex);
-		audio = _get_aid_audio(aid);
-	}
+	MutexLock aid_lock(aid_mutex);
+	SpxAudio *audio = _get_aid_audio(aid);
 	if (audio == nullptr) {
 		return false;
 	}
-	return audio->restart(aid);
+	GdBool restarted = audio->restart(aid);
+	if (!restarted) {
+		aid_audios.erase(aid);
+	}
+	return restarted;
 }
 
 void SpxAudioMgr::set_loop(GdInt aid, GdBool loop) {

--- a/modules/spx/spx_audio_mgr.h
+++ b/modules/spx/spx_audio_mgr.h
@@ -78,6 +78,7 @@ public:
 	SPX_API void pause(GdInt aid);
 	SPX_API void resume(GdInt aid);
 	SPX_API void stop(GdInt aid);
+	SPX_API GdBool restart(GdInt aid);
 	SPX_API void set_loop(GdInt aid, GdBool loop);
 	SPX_API GdBool get_loop(GdInt aid);
 

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -136,6 +136,10 @@ void gdspx_audio_stop(GdInt *aid) {
 	 audioMgr->stop(*aid);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_audio_restart(GdInt *aid, GdBool *ret_val) {
+	*ret_val = audioMgr->restart(*aid);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_audio_set_loop(GdInt *aid, GdBool *loop) {
 	 audioMgr->set_loop(*aid, *loop);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -181,6 +181,16 @@ gdspx_audio_stop(aid_low,aid_high) {
 	FreeGdInt(_arg0); 
 
 }
+gdspx_audio_restart(aid_low,aid_high) {
+	var _gdFuncPtr = Module._gdspx_audio_restart; 
+	var _retValue = AllocGdBool();
+	var _arg0 = Module._gdspx_new_int(aid_high, aid_low);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdInt(_arg0); 
+	var _finalRetValue = ToJsBool(_retValue);
+	FreeGdBool(_retValue); 
+	return _finalRetValue
+}
 gdspx_audio_set_loop(aid_low,aid_high,loop) {
 	var _gdFuncPtr = Module._gdspx_audio_set_loop; 
 	


### PR DESCRIPTION
## Summary

This PR adds a playback-level restart API to the SPX audio layer.

Changes:
- add `restart(aid)` to `SpxAudio`
- add `restart(aid)` to `SpxAudioMgr`
- expose `spx_audio_restart` through the native gdextension bridge
- expose `spx_audio_restart` through the web bridge

## Why

The upper animation layer needs to restart an existing audio playback at animation loop boundaries.

Using a restart primitive at the engine layer lets us:
- restart the same playback id when it is still alive
- avoid forcing the caller to stop and recreate playback every cycle
- share the same behavior across native and web backends

## Testing

- Not compiled in this environment
- Interface wiring was verified locally by code integration on the SPX side