### PR TITLE
feat(pen): add stamp-with-transform manager api

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -257,8 +257,8 @@ static void gdextension_spx_pen_set_pen_size_to(GdObj obj, GdFloat size) {
 static void gdextension_spx_pen_set_pen_stamp_texture(GdObj obj, GdString texture_path) {
 	penMgr->set_pen_stamp_texture(obj, texture_path);
 }
-static void gdextension_spx_pen_pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
-	penMgr->pen_stamp_with_transform(obj, position, texture_path, rotation, scale);
+static void gdextension_spx_pen_pen_stamp_with_transform(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
+	penMgr->pen_stamp_with_transform(obj, texture_path, position, rotation_radians, scale);
 }
 static void gdextension_spx_physics_raycast(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_val) {
 	*ret_val = physicsMgr->raycast(from, to, collision_mask);

--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -257,6 +257,9 @@ static void gdextension_spx_pen_set_pen_size_to(GdObj obj, GdFloat size) {
 static void gdextension_spx_pen_set_pen_stamp_texture(GdObj obj, GdString texture_path) {
 	penMgr->set_pen_stamp_texture(obj, texture_path);
 }
+static void gdextension_spx_pen_pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
+	penMgr->pen_stamp_with_transform(obj, position, texture_path, rotation, scale);
+}
 static void gdextension_spx_physics_raycast(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_val) {
 	*ret_val = physicsMgr->raycast(from, to, collision_mask);
 }
@@ -1082,6 +1085,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_change_pen_size_by);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_set_pen_size_to);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_set_pen_stamp_texture);
+	REGISTER_SPX_INTERFACE_FUNC(spx_pen_pen_stamp_with_transform);
 	REGISTER_SPX_INTERFACE_FUNC(spx_physics_raycast);
 	REGISTER_SPX_INTERFACE_FUNC(spx_physics_check_collision);
 	REGISTER_SPX_INTERFACE_FUNC(spx_physics_check_touched_camera_boundaries);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -289,6 +289,7 @@ typedef void (*GDExtensionSpxPenSetPenTo)(GdObj obj, GdInt property, GdFloat val
 typedef void (*GDExtensionSpxPenChangePenSizeBy)(GdObj obj, GdFloat amount);
 typedef void (*GDExtensionSpxPenSetPenSizeTo)(GdObj obj, GdFloat size);
 typedef void (*GDExtensionSpxPenSetPenStampTexture)(GdObj obj, GdString texture_path);
+typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
 // SpxPhysics
 typedef void (*GDExtensionSpxPhysicsRaycast)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_value);
 typedef void (*GDExtensionSpxPhysicsCheckCollision)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdBool *ret_value);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -289,7 +289,7 @@ typedef void (*GDExtensionSpxPenSetPenTo)(GdObj obj, GdInt property, GdFloat val
 typedef void (*GDExtensionSpxPenChangePenSizeBy)(GdObj obj, GdFloat amount);
 typedef void (*GDExtensionSpxPenSetPenSizeTo)(GdObj obj, GdFloat size);
 typedef void (*GDExtensionSpxPenSetPenStampTexture)(GdObj obj, GdString texture_path);
-typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
+typedef void (*GDExtensionSpxPenPenStampWithTransform)(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
 // SpxPhysics
 typedef void (*GDExtensionSpxPhysicsRaycast)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_value);
 typedef void (*GDExtensionSpxPhysicsCheckCollision)(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdBool *ret_value);

--- a/modules/spx/spx_pen.cpp
+++ b/modules/spx/spx_pen.cpp
@@ -144,17 +144,24 @@ void SpxPen::erase_all() {
 	is_pen_down = false;
 }
 
-void SpxPen::stamp() {
-	if (!stamp_texture.is_valid()) {
+void SpxPen::_stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation, GdVec2 scale) {
+	if (!texture.is_valid()) {
 		return;
 	}
 	if (pen_root == nullptr) {
 		return;
 	}
+	current_pen_pos = position;
 	Sprite2D *new_stamp = memnew(Sprite2D);
-	new_stamp->set_texture(stamp_texture);
-	new_stamp->set_position(current_pen_pos);
+	new_stamp->set_texture(texture);
+	new_stamp->set_position(position);
+	new_stamp->set_rotation(rotation);
+	new_stamp->set_scale(scale);
 	pen_root->add_child(new_stamp);
+}
+
+void SpxPen::stamp() {
+	_stamp_texture(stamp_texture, current_pen_pos, 0.0f, Vector2(1.0f, 1.0f));
 }
 
 void SpxPen::move_to(GdVec2 position) {
@@ -213,4 +220,10 @@ void SpxPen::set_size_to(GdFloat size) {
 void SpxPen::set_stamp_texture(GdString texture_path) {
 	auto path_str = SpxStr(texture_path);
 	stamp_texture = resMgr->load_texture(path_str, false);
+}
+
+void SpxPen::stamp_with_transform(GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
+	auto path_str = SpxStr(texture_path);
+	Ref<Texture2D> texture = resMgr->load_texture(path_str, false);
+	_stamp_texture(texture, position, rotation, scale);
 }

--- a/modules/spx/spx_pen.cpp
+++ b/modules/spx/spx_pen.cpp
@@ -54,6 +54,7 @@ void SpxPen::on_create(GdInt id, Node *root) {
 	is_pen_down = false;
 	min_draw_distance = 1.0f;
 	pen_properties.transparency = 1.0f;
+	stamp_texture_path = String();
 }
 
 void SpxPen::_destroy_pen_root() {
@@ -144,20 +145,29 @@ void SpxPen::erase_all() {
 	is_pen_down = false;
 }
 
-void SpxPen::_stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation, GdVec2 scale) {
+void SpxPen::_stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
 	if (!texture.is_valid()) {
 		return;
 	}
 	if (pen_root == nullptr) {
 		return;
 	}
-	current_pen_pos = position;
 	Sprite2D *new_stamp = memnew(Sprite2D);
 	new_stamp->set_texture(texture);
 	new_stamp->set_position(position);
-	new_stamp->set_rotation(rotation);
+	new_stamp->set_rotation(rotation_radians);
 	new_stamp->set_scale(scale);
 	pen_root->add_child(new_stamp);
+}
+
+Ref<Texture2D> SpxPen::_resolve_stamp_texture(const String &texture_path) {
+	if (stamp_texture.is_valid() && stamp_texture_path == texture_path) {
+		return stamp_texture;
+	}
+
+	stamp_texture_path = texture_path;
+	stamp_texture = resMgr->load_texture(texture_path, false);
+	return stamp_texture;
 }
 
 void SpxPen::stamp() {
@@ -218,12 +228,10 @@ void SpxPen::set_size_to(GdFloat size) {
 }
 
 void SpxPen::set_stamp_texture(GdString texture_path) {
-	auto path_str = SpxStr(texture_path);
-	stamp_texture = resMgr->load_texture(path_str, false);
+	_resolve_stamp_texture(SpxStr(texture_path));
 }
 
-void SpxPen::stamp_with_transform(GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
-	auto path_str = SpxStr(texture_path);
-	Ref<Texture2D> texture = resMgr->load_texture(path_str, false);
-	_stamp_texture(texture, position, rotation, scale);
+void SpxPen::stamp_with_transform(GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
+	Ref<Texture2D> texture = _resolve_stamp_texture(SpxStr(texture_path));
+	_stamp_texture(texture, position, rotation_radians, scale);
 }

--- a/modules/spx/spx_pen.h
+++ b/modules/spx/spx_pen.h
@@ -65,6 +65,7 @@ private:
 	Line2D *_create_new_line();
 	void _start_new_line();
 	Color _get_current_color() const;
+	void _stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation, GdVec2 scale);
 
 public:
 	void on_create(GdInt id, Node *root);
@@ -86,6 +87,7 @@ public:
 	void change_size_by(GdFloat amount);
 	void set_size_to(GdFloat size);
 	void set_stamp_texture(GdString texture_path);
+	void stamp_with_transform(GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
 };
 
 #endif // SPX_PEN_H

--- a/modules/spx/spx_pen.h
+++ b/modules/spx/spx_pen.h
@@ -59,13 +59,15 @@ private:
 	bool move_by_mouse = false;
 
 	Ref<Texture2D> stamp_texture;
+	String stamp_texture_path;
 
 private:
 	void _destroy_pen_root();
 	Line2D *_create_new_line();
 	void _start_new_line();
 	Color _get_current_color() const;
-	void _stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation, GdVec2 scale);
+	void _stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
+	Ref<Texture2D> _resolve_stamp_texture(const String &texture_path);
 
 public:
 	void on_create(GdInt id, Node *root);
@@ -87,7 +89,8 @@ public:
 	void change_size_by(GdFloat amount);
 	void set_size_to(GdFloat size);
 	void set_stamp_texture(GdString texture_path);
-	void stamp_with_transform(GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
+	// rotation_radians is in radians.
+	void stamp_with_transform(GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
 };
 
 #endif // SPX_PEN_H

--- a/modules/spx/spx_pen_mgr.cpp
+++ b/modules/spx/spx_pen_mgr.cpp
@@ -111,6 +111,6 @@ void SpxPenMgr::set_pen_stamp_texture(GdObj obj, GdString texture_path) {
 	SPX_WITH_PEN_OR_RETURN(obj, pen->set_stamp_texture(texture_path))
 }
 
-void SpxPenMgr::pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
-	SPX_WITH_PEN_OR_RETURN(obj, pen->stamp_with_transform(position, texture_path, rotation, scale))
+void SpxPenMgr::pen_stamp_with_transform(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
+	SPX_WITH_PEN_OR_RETURN(obj, pen->stamp_with_transform(texture_path, position, rotation_radians, scale))
 }

--- a/modules/spx/spx_pen_mgr.cpp
+++ b/modules/spx/spx_pen_mgr.cpp
@@ -110,3 +110,7 @@ void SpxPenMgr::set_pen_size_to(GdObj obj, GdFloat size) {
 void SpxPenMgr::set_pen_stamp_texture(GdObj obj, GdString texture_path) {
 	SPX_WITH_PEN_OR_RETURN(obj, pen->set_stamp_texture(texture_path))
 }
+
+void SpxPenMgr::pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale) {
+	SPX_WITH_PEN_OR_RETURN(obj, pen->stamp_with_transform(position, texture_path, rotation, scale))
+}

--- a/modules/spx/spx_pen_mgr.h
+++ b/modules/spx/spx_pen_mgr.h
@@ -59,6 +59,7 @@ public:
 	SPX_API void change_pen_size_by(GdObj obj, GdFloat amount);
 	SPX_API void set_pen_size_to(GdObj obj, GdFloat size);
 	SPX_API void set_pen_stamp_texture(GdObj obj, GdString texture_path);
+	SPX_API void pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
 };
 
 #endif // SPX_PEN_MGR_H

--- a/modules/spx/spx_pen_mgr.h
+++ b/modules/spx/spx_pen_mgr.h
@@ -59,7 +59,8 @@ public:
 	SPX_API void change_pen_size_by(GdObj obj, GdFloat amount);
 	SPX_API void set_pen_size_to(GdObj obj, GdFloat size);
 	SPX_API void set_pen_stamp_texture(GdObj obj, GdString texture_path);
-	SPX_API void pen_stamp_with_transform(GdObj obj, GdVec2 position, GdString texture_path, GdFloat rotation, GdVec2 scale);
+	// rotation_radians is in radians.
+	SPX_API void pen_stamp_with_transform(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
 };
 
 #endif // SPX_PEN_MGR_H

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -344,8 +344,8 @@ void gdspx_pen_set_pen_stamp_texture(GdObj *obj, GdString *texture_path) {
 	 penMgr->set_pen_stamp_texture(*obj, *texture_path);
 }
 EMSCRIPTEN_KEEPALIVE
-void gdspx_pen_pen_stamp_with_transform(GdObj *obj, GdVec2 *position, GdString *texture_path, GdFloat *rotation, GdVec2 *scale) {
-	 penMgr->pen_stamp_with_transform(*obj, *position, *texture_path, *rotation, *scale);
+void gdspx_pen_pen_stamp_with_transform(GdObj *obj, GdString *texture_path, GdVec2 *position, GdFloat *rotation_radians, GdVec2 *scale) {
+	 penMgr->pen_stamp_with_transform(*obj, *texture_path, *position, *rotation_radians, *scale);
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_physics_raycast(GdVec2 *from, GdVec2 *to, GdInt *collision_mask, GdObj *ret_val) {

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -344,6 +344,10 @@ void gdspx_pen_set_pen_stamp_texture(GdObj *obj, GdString *texture_path) {
 	 penMgr->set_pen_stamp_texture(*obj, *texture_path);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_pen_pen_stamp_with_transform(GdObj *obj, GdVec2 *position, GdString *texture_path, GdFloat *rotation, GdVec2 *scale) {
+	 penMgr->pen_stamp_with_transform(*obj, *position, *texture_path, *rotation, *scale);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_physics_raycast(GdVec2 *from, GdVec2 *to, GdInt *collision_mask, GdObj *ret_val) {
 	*ret_val = physicsMgr->raycast(*from, *to, *collision_mask);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -670,18 +670,18 @@ gdspx_pen_set_pen_stamp_texture(obj_low,obj_high,texture_path) {
 	FreeGdString(_arg1); 
 
 }
-gdspx_pen_pen_stamp_with_transform(obj_low,obj_high,position,texture_path,rotation,scale) {
+gdspx_pen_pen_stamp_with_transform(obj_low,obj_high,texture_path,position,rotation_radians,scale) {
 	var _gdFuncPtr = Module._gdspx_pen_pen_stamp_with_transform; 
 	
 	var _arg0 = Module._gdspx_new_obj(obj_high, obj_low);
-	var _arg1 = ToGdVec2(position);
-	var _arg2 = ToGdString(texture_path);
-	var _arg3 = ToGdFloat(rotation);
+	var _arg1 = ToGdString(texture_path);
+	var _arg2 = ToGdVec2(position);
+	var _arg3 = ToGdFloat(rotation_radians);
 	var _arg4 = ToGdVec2(scale);
 	_gdFuncPtr(_arg0, _arg1, _arg2, _arg3, _arg4);
 	FreeGdObj(_arg0); 
-	FreeGdVec2(_arg1); 
-	FreeGdString(_arg2); 
+	FreeGdString(_arg1); 
+	FreeGdVec2(_arg2); 
 	FreeGdFloat(_arg3); 
 	FreeGdVec2(_arg4); 
 

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -670,6 +670,22 @@ gdspx_pen_set_pen_stamp_texture(obj_low,obj_high,texture_path) {
 	FreeGdString(_arg1); 
 
 }
+gdspx_pen_pen_stamp_with_transform(obj_low,obj_high,position,texture_path,rotation,scale) {
+	var _gdFuncPtr = Module._gdspx_pen_pen_stamp_with_transform; 
+	
+	var _arg0 = Module._gdspx_new_obj(obj_high, obj_low);
+	var _arg1 = ToGdVec2(position);
+	var _arg2 = ToGdString(texture_path);
+	var _arg3 = ToGdFloat(rotation);
+	var _arg4 = ToGdVec2(scale);
+	_gdFuncPtr(_arg0, _arg1, _arg2, _arg3, _arg4);
+	FreeGdObj(_arg0); 
+	FreeGdVec2(_arg1); 
+	FreeGdString(_arg2); 
+	FreeGdFloat(_arg3); 
+	FreeGdVec2(_arg4); 
+
+}
 gdspx_physics_raycast(from,to,collision_mask_low,collision_mask_high) {
 	var _gdFuncPtr = Module._gdspx_physics_raycast; 
 	var _retValue = AllocGdObj();


### PR DESCRIPTION
## Summary
- add `pen_stamp_with_transform` to `SpxPenMgr`
- let the pen manager accept position, texture path, rotation, and final scale in one call
- apply stamp transform directly inside `SpxPen`
- regenerate/export native and web-facing pen bindings for the new API

## Testing
- verified through the spx-side `go test .` integration coverage
- Godot module build not run in this step