### PR TITLE
spx: add bulk sprite transform sync api

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -503,6 +503,9 @@ static void gdextension_spx_sprite_is_sprite_alive(GdObj obj, GdBool *ret_val) {
 static void gdextension_spx_sprite_set_position(GdObj obj, GdVec2 pos) {
 	spriteMgr->set_position(obj, pos);
 }
+static void gdextension_spx_sprite_set_transform(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot) {
+	spriteMgr->set_transform(obj, pos, rot, scale, visible, pivot);
+}
 static void gdextension_spx_sprite_get_position(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_position(obj);
 }
@@ -1167,6 +1170,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_destroy_sprite);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_is_sprite_alive);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_set_position);
+	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_set_transform);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_get_position);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_set_rotation);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_get_rotation);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -376,6 +376,7 @@ typedef void (*GDExtensionSpxSpriteCloneSprite)(GdObj obj, GdObj *ret_value);
 typedef void (*GDExtensionSpxSpriteDestroySprite)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteIsSpriteAlive)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteSetPosition)(GdObj obj, GdVec2 pos);
+typedef void (*GDExtensionSpxSpriteSetTransform)(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot);
 typedef void (*GDExtensionSpxSpriteGetPosition)(GdObj obj, GdVec2 *ret_value);
 typedef void (*GDExtensionSpxSpriteSetRotation)(GdObj obj, GdFloat rot);
 typedef void (*GDExtensionSpxSpriteGetRotation)(GdObj obj, GdFloat *ret_value);

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -369,6 +369,17 @@ void SpxSpriteMgr::set_position(GdObj obj, GdVec2 pos) {
 	sprite->set_position(GdVec2(pos.x, -pos.y));
 }
 
+void SpxSpriteMgr::set_transform(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot) {
+	SPX_REQUIRE_SPRITE_VOID()
+	sprite->set_position(GdVec2(pos.x, -pos.y));
+	sprite->set_rotation(rot);
+	sprite->set_scale(scale);
+	sprite->set_visible(visible);
+	sprite->on_set_visible(visible);
+	pivot.y = -pivot.y;
+	sprite->set_pivot(pivot);
+}
+
 void SpxSpriteMgr::set_rotation(GdObj obj, GdFloat rot) {
 	SPX_REQUIRE_SPRITE_VOID()
 	sprite->set_rotation(rot);

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -167,6 +167,7 @@ public:
 	SPX_API GdBool destroy_sprite(GdObj obj);
 	SPX_API GdBool is_sprite_alive(GdObj obj);
 	SPX_API void set_position(GdObj obj, GdVec2 pos);
+	SPX_API void set_transform(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot);
 	SPX_API GdVec2 get_position(GdObj obj);
 	SPX_API void set_rotation(GdObj obj, GdFloat rot);
 	SPX_API GdFloat get_rotation(GdObj obj);

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -672,6 +672,10 @@ void gdspx_sprite_set_position(GdObj *obj, GdVec2 *pos) {
 	 spriteMgr->set_position(*obj, *pos);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_set_transform(GdObj *obj, GdVec2 *pos, GdFloat *rot, GdVec2 *scale, GdBool *visible, GdVec2 *pivot) {
+	 spriteMgr->set_transform(*obj, *pos, *rot, *scale, *visible, *pivot);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_get_position(GdObj *obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_position(*obj);
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -1512,6 +1512,24 @@ gdspx_sprite_set_position(obj_low,obj_high,pos) {
 	FreeGdVec2(_arg1); 
 
 }
+gdspx_sprite_set_transform(obj_low,obj_high,pos,rot,scale,visible,pivot) {
+	var _gdFuncPtr = Module._gdspx_sprite_set_transform; 
+	
+	var _arg0 = Module._gdspx_new_obj(obj_high, obj_low);
+	var _arg1 = ToGdVec2(pos);
+	var _arg2 = ToGdFloat(rot);
+	var _arg3 = ToGdVec2(scale);
+	var _arg4 = ToGdBool(visible);
+	var _arg5 = ToGdVec2(pivot);
+	_gdFuncPtr(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
+	FreeGdObj(_arg0); 
+	FreeGdVec2(_arg1); 
+	FreeGdFloat(_arg2); 
+	FreeGdVec2(_arg3); 
+	FreeGdBool(_arg4); 
+	FreeGdVec2(_arg5); 
+
+}
 gdspx_sprite_get_position(obj_low,obj_high) {
 	var _gdFuncPtr = Module._gdspx_sprite_get_position; 
 	var _retValue = AllocGdVec2();


### PR DESCRIPTION
## Summary

- add `set_transform` to the SPX sprite manager API
- update native and web bindings to expose the new entrypoint
- sync position, rotation, scale, visibility, and pivot in one call to reduce per-sprite transform update overhead

## Details

The new API keeps the existing transform semantics in one place:
- position and pivot still apply the Y flip used by the current bridge
- visibility still triggers `on_set_visible`
- native and web entrypoints stay aligned

## Testing

- not run in the godot repo