### PR TITLE
perf: optimize web batch sync with shared transfer buffer

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -62,963 +62,1342 @@ static void gdextension_spx_global_register_callbacks(GDExtensionSpxCallbackInfo
 static void gdextension_spx_audio_stop_all() {
 	audioMgr->stop_all();
 }
+
 static void gdextension_spx_audio_create_audio(GdObj *ret_val) {
 	*ret_val = audioMgr->create_audio();
 }
+
 static void gdextension_spx_audio_destroy_audio(GdObj obj) {
 	audioMgr->destroy_audio(obj);
 }
+
 static void gdextension_spx_audio_set_pitch(GdObj obj, GdFloat pitch) {
 	audioMgr->set_pitch(obj, pitch);
 }
+
 static void gdextension_spx_audio_get_pitch(GdObj obj, GdFloat *ret_val) {
 	*ret_val = audioMgr->get_pitch(obj);
 }
+
 static void gdextension_spx_audio_set_pan(GdObj obj, GdFloat pan) {
 	audioMgr->set_pan(obj, pan);
 }
+
 static void gdextension_spx_audio_get_pan(GdObj obj, GdFloat *ret_val) {
 	*ret_val = audioMgr->get_pan(obj);
 }
+
 static void gdextension_spx_audio_set_volume(GdObj obj, GdFloat volume) {
 	audioMgr->set_volume(obj, volume);
 }
+
 static void gdextension_spx_audio_get_volume(GdObj obj, GdFloat *ret_val) {
 	*ret_val = audioMgr->get_volume(obj);
 }
+
 static void gdextension_spx_audio_play_with_attenuation(GdObj obj, GdString path, GdObj owner_id, GdFloat attenuation, GdFloat max_distance, GdInt *ret_val) {
 	*ret_val = audioMgr->play_with_attenuation(obj, path, owner_id, attenuation, max_distance);
 }
+
 static void gdextension_spx_audio_play(GdObj obj, GdString path, GdInt *ret_val) {
 	*ret_val = audioMgr->play(obj, path);
 }
+
 static void gdextension_spx_audio_pause(GdInt aid) {
 	audioMgr->pause(aid);
 }
+
 static void gdextension_spx_audio_resume(GdInt aid) {
 	audioMgr->resume(aid);
 }
+
 static void gdextension_spx_audio_stop(GdInt aid) {
 	audioMgr->stop(aid);
 }
+
 static void gdextension_spx_audio_restart(GdInt aid, GdBool *ret_val) {
 	*ret_val = audioMgr->restart(aid);
 }
+
 static void gdextension_spx_audio_set_loop(GdInt aid, GdBool loop) {
 	audioMgr->set_loop(aid, loop);
 }
+
 static void gdextension_spx_audio_get_loop(GdInt aid, GdBool *ret_val) {
 	*ret_val = audioMgr->get_loop(aid);
 }
+
 static void gdextension_spx_audio_get_timer(GdInt aid, GdFloat *ret_val) {
 	*ret_val = audioMgr->get_timer(aid);
 }
+
 static void gdextension_spx_audio_set_timer(GdInt aid, GdFloat time) {
 	audioMgr->set_timer(aid, time);
 }
+
 static void gdextension_spx_audio_is_playing(GdInt aid, GdBool *ret_val) {
 	*ret_val = audioMgr->is_playing(aid);
 }
+
 static void gdextension_spx_camera_get_camera_position(GdVec2 *ret_val) {
 	*ret_val = cameraMgr->get_camera_position();
 }
+
 static void gdextension_spx_camera_set_camera_position(GdVec2 position) {
 	cameraMgr->set_camera_position(position);
 }
+
 static void gdextension_spx_camera_get_camera_zoom(GdVec2 *ret_val) {
 	*ret_val = cameraMgr->get_camera_zoom();
 }
+
 static void gdextension_spx_camera_set_camera_zoom(GdVec2 size) {
 	cameraMgr->set_camera_zoom(size);
 }
+
 static void gdextension_spx_camera_get_viewport_rect(GdRect2 *ret_val) {
 	*ret_val = cameraMgr->get_viewport_rect();
 }
+
 static void gdextension_spx_camera_get_global_camera_rect(GdRect2 *ret_val) {
 	*ret_val = cameraMgr->get_global_camera_rect();
 }
+
 static void gdextension_spx_camera_get_stage_limits_rect(GdRect2 *ret_val) {
 	*ret_val = cameraMgr->get_stage_limits_rect();
 }
+
 static void gdextension_spx_camera_set_camera_limit(GdInt side, GdInt limit) {
 	cameraMgr->set_camera_limit(side, limit);
 }
+
 static void gdextension_spx_camera_set_camera_smoothing(GdBool enabled) {
 	cameraMgr->set_camera_smoothing(enabled);
 }
+
 static void gdextension_spx_debug_debug_draw_circle(GdVec2 pos, GdFloat radius, GdColor color) {
 	debugMgr->debug_draw_circle(pos, radius, color);
 }
+
 static void gdextension_spx_debug_debug_draw_rect(GdVec2 pos, GdVec2 size, GdColor color) {
 	debugMgr->debug_draw_rect(pos, size, color);
 }
+
 static void gdextension_spx_debug_debug_draw_line(GdVec2 from, GdVec2 to, GdColor color) {
 	debugMgr->debug_draw_line(from, to, color);
 }
+
 static void gdextension_spx_ext_request_exit(GdInt exit_code) {
 	extMgr->request_exit(exit_code);
 }
+
 static void gdextension_spx_ext_request_reset(GdInt exit_code) {
 	extMgr->request_reset(exit_code);
 }
+
 static void gdextension_spx_ext_request_restart() {
 	extMgr->request_restart();
 }
+
 static void gdextension_spx_ext_on_runtime_panic(GdString msg) {
 	extMgr->on_runtime_panic(msg);
 }
+
 static void gdextension_spx_ext_pause() {
 	extMgr->pause();
 }
+
 static void gdextension_spx_ext_resume() {
 	extMgr->resume();
 }
+
 static void gdextension_spx_ext_is_paused(GdBool *ret_val) {
 	*ret_val = extMgr->is_paused();
 }
+
 static void gdextension_spx_ext_next_frame() {
 	extMgr->next_frame();
 }
+
 static void gdextension_spx_ext_set_layer_sorter_mode(GdInt mode) {
 	extMgr->set_layer_sorter_mode(mode);
 }
+
 static void gdextension_spx_input_get_global_mouse_pos(GdVec2 *ret_val) {
 	*ret_val = inputMgr->get_global_mouse_pos();
 }
+
 static void gdextension_spx_input_get_key(GdInt key, GdBool *ret_val) {
 	*ret_val = inputMgr->get_key(key);
 }
+
 static void gdextension_spx_input_get_mouse_state(GdInt mouse_id, GdBool *ret_val) {
 	*ret_val = inputMgr->get_mouse_state(mouse_id);
 }
+
 static void gdextension_spx_input_get_key_state(GdInt key, GdInt *ret_val) {
 	*ret_val = inputMgr->get_key_state(key);
 }
+
 static void gdextension_spx_input_get_axis(GdString neg_action, GdString pos_action, GdFloat *ret_val) {
 	*ret_val = inputMgr->get_axis(neg_action, pos_action);
 }
+
 static void gdextension_spx_input_is_action_pressed(GdString action, GdBool *ret_val) {
 	*ret_val = inputMgr->is_action_pressed(action);
 }
+
 static void gdextension_spx_input_is_action_just_pressed(GdString action, GdBool *ret_val) {
 	*ret_val = inputMgr->is_action_just_pressed(action);
 }
+
 static void gdextension_spx_input_is_action_just_released(GdString action, GdBool *ret_val) {
 	*ret_val = inputMgr->is_action_just_released(action);
 }
+
+static void gdextension_spx_input_register_action(GdString action, GdInt *ret_val) {
+	*ret_val = inputMgr->register_action(action);
+}
+
+static void gdextension_spx_input_get_axis_id(GdInt neg_action_id, GdInt pos_action_id, GdFloat *ret_val) {
+	*ret_val = inputMgr->get_axis_id(neg_action_id, pos_action_id);
+}
+
+static void gdextension_spx_input_is_action_pressed_id(GdInt action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_pressed_id(action_id);
+}
+
+static void gdextension_spx_input_is_action_just_pressed_id(GdInt action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_just_pressed_id(action_id);
+}
+
+static void gdextension_spx_input_is_action_just_released_id(GdInt action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_just_released_id(action_id);
+}
+
+static void gdextension_spx_input_write_snapshot(float *out, int len) {
+	inputMgr->write_snapshot(out, len);
+}
+
 static void gdextension_spx_navigation_setup_path_finder_with_size(GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug) {
 	navigationMgr->setup_path_finder_with_size(grid_size, cell_size, with_jump, with_debug);
 }
+
 static void gdextension_spx_navigation_setup_path_finder(GdBool with_jump) {
 	navigationMgr->setup_path_finder(with_jump);
 }
+
 static void gdextension_spx_navigation_set_obstacle(GdObj obj, GdBool enabled) {
 	navigationMgr->set_obstacle(obj, enabled);
 }
+
 static void gdextension_spx_navigation_find_path(GdVec2 p_from, GdVec2 p_to, GdBool with_jump, GdArray *ret_val) {
 	*ret_val = navigationMgr->find_path(p_from, p_to, with_jump);
 }
+
 static void gdextension_spx_pen_destroy_all_pens() {
 	penMgr->destroy_all_pens();
 }
+
 static void gdextension_spx_pen_create_pen(GdObj *ret_val) {
 	*ret_val = penMgr->create_pen();
 }
+
 static void gdextension_spx_pen_destroy_pen(GdObj obj) {
 	penMgr->destroy_pen(obj);
 }
+
 static void gdextension_spx_pen_pen_stamp(GdObj obj) {
 	penMgr->pen_stamp(obj);
 }
+
 static void gdextension_spx_pen_move_pen_to(GdObj obj, GdVec2 position) {
 	penMgr->move_pen_to(obj, position);
 }
+
 static void gdextension_spx_pen_pen_down(GdObj obj, GdBool move_by_mouse) {
 	penMgr->pen_down(obj, move_by_mouse);
 }
+
 static void gdextension_spx_pen_pen_up(GdObj obj) {
 	penMgr->pen_up(obj);
 }
+
 static void gdextension_spx_pen_set_pen_color_to(GdObj obj, GdColor color) {
 	penMgr->set_pen_color_to(obj, color);
 }
+
 static void gdextension_spx_pen_change_pen_by(GdObj obj, GdInt property, GdFloat amount) {
 	penMgr->change_pen_by(obj, property, amount);
 }
+
 static void gdextension_spx_pen_set_pen_to(GdObj obj, GdInt property, GdFloat value) {
 	penMgr->set_pen_to(obj, property, value);
 }
+
 static void gdextension_spx_pen_change_pen_size_by(GdObj obj, GdFloat amount) {
 	penMgr->change_pen_size_by(obj, amount);
 }
+
 static void gdextension_spx_pen_set_pen_size_to(GdObj obj, GdFloat size) {
 	penMgr->set_pen_size_to(obj, size);
 }
+
 static void gdextension_spx_pen_set_pen_stamp_texture(GdObj obj, GdString texture_path) {
 	penMgr->set_pen_stamp_texture(obj, texture_path);
 }
+
 static void gdextension_spx_pen_pen_stamp_with_transform(GdObj obj, GdString texture_path, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {
 	penMgr->pen_stamp_with_transform(obj, texture_path, position, rotation_radians, scale);
 }
+
 static void gdextension_spx_physics_raycast(GdVec2 from, GdVec2 to, GdInt collision_mask, GdObj *ret_val) {
 	*ret_val = physicsMgr->raycast(from, to, collision_mask);
 }
+
 static void gdextension_spx_physics_check_collision(GdVec2 from, GdVec2 to, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdBool *ret_val) {
 	*ret_val = physicsMgr->check_collision(from, to, collision_mask, collide_with_areas, collide_with_bodies);
 }
+
 static void gdextension_spx_physics_check_touched_camera_boundaries(GdObj obj, GdInt *ret_val) {
 	*ret_val = physicsMgr->check_touched_camera_boundaries(obj);
 }
+
 static void gdextension_spx_physics_check_touched_camera_boundary(GdObj obj, GdInt board_type, GdBool *ret_val) {
 	*ret_val = physicsMgr->check_touched_camera_boundary(obj, board_type);
 }
+
 static void gdextension_spx_physics_check_nearest_touched_camera_boundary(GdObj obj, GdInt *ret_val) {
 	*ret_val = physicsMgr->check_nearest_touched_camera_boundary(obj);
 }
+
 static void gdextension_spx_physics_check_touched_stage_boundaries(GdObj obj, GdInt *ret_val) {
 	*ret_val = physicsMgr->check_touched_stage_boundaries(obj);
 }
+
 static void gdextension_spx_physics_check_touched_stage_boundary(GdObj obj, GdInt board_type, GdBool *ret_val) {
 	*ret_val = physicsMgr->check_touched_stage_boundary(obj, board_type);
 }
+
 static void gdextension_spx_physics_check_nearest_touched_stage_boundary(GdObj obj, GdInt *ret_val) {
 	*ret_val = physicsMgr->check_nearest_touched_stage_boundary(obj);
 }
+
 static void gdextension_spx_physics_set_collision_system_type(GdBool is_collision_by_alpha) {
 	physicsMgr->set_collision_system_type(is_collision_by_alpha);
 }
+
 static void gdextension_spx_physics_set_global_gravity(GdFloat gravity) {
 	physicsMgr->set_global_gravity(gravity);
 }
+
 static void gdextension_spx_physics_get_global_gravity(GdFloat *ret_val) {
 	*ret_val = physicsMgr->get_global_gravity();
 }
+
 static void gdextension_spx_physics_set_global_friction(GdFloat friction) {
 	physicsMgr->set_global_friction(friction);
 }
+
 static void gdextension_spx_physics_get_global_friction(GdFloat *ret_val) {
 	*ret_val = physicsMgr->get_global_friction();
 }
+
 static void gdextension_spx_physics_set_global_air_drag(GdFloat air_drag) {
 	physicsMgr->set_global_air_drag(air_drag);
 }
+
 static void gdextension_spx_physics_get_global_air_drag(GdFloat *ret_val) {
 	*ret_val = physicsMgr->get_global_air_drag();
 }
+
 static void gdextension_spx_physics_check_collision_rect(GdVec2 pos, GdVec2 size, GdInt collision_mask, GdArray *ret_val) {
 	*ret_val = physicsMgr->check_collision_rect(pos, size, collision_mask);
 }
+
 static void gdextension_spx_physics_check_collision_circle(GdVec2 pos, GdFloat radius, GdInt collision_mask, GdArray *ret_val) {
 	*ret_val = physicsMgr->check_collision_circle(pos, radius, collision_mask);
 }
+
 static void gdextension_spx_physics_raycast_with_details(GdVec2 from, GdVec2 to, GdArray ignore_sprites, GdInt collision_mask, GdBool collide_with_areas, GdBool collide_with_bodies, GdArray *ret_val) {
 	*ret_val = physicsMgr->raycast_with_details(from, to, ignore_sprites, collision_mask, collide_with_areas, collide_with_bodies);
 }
+
 static void gdextension_spx_platform_set_stretch_mode(GdBool enable) {
 	platformMgr->set_stretch_mode(enable);
 }
+
 static void gdextension_spx_platform_set_stretch_aspect(GdBool is_keep) {
 	platformMgr->set_stretch_aspect(is_keep);
 }
+
 static void gdextension_spx_platform_set_stretch_content_scale(GdInt width, GdInt height) {
 	platformMgr->set_stretch_content_scale(width, height);
 }
+
 static void gdextension_spx_platform_set_window_position(GdVec2 pos) {
 	platformMgr->set_window_position(pos);
 }
+
 static void gdextension_spx_platform_get_window_position(GdVec2 *ret_val) {
 	*ret_val = platformMgr->get_window_position();
 }
+
 static void gdextension_spx_platform_set_window_size(GdInt width, GdInt height, GdBool with_content_scale) {
 	platformMgr->set_window_size(width, height, with_content_scale);
 }
+
 static void gdextension_spx_platform_get_window_size(GdVec2 *ret_val) {
 	*ret_val = platformMgr->get_window_size();
 }
+
 static void gdextension_spx_platform_set_window_title(GdString title) {
 	platformMgr->set_window_title(title);
 }
+
 static void gdextension_spx_platform_get_window_title(GdString *ret_val) {
 	*ret_val = platformMgr->get_window_title();
 }
+
 static void gdextension_spx_platform_set_window_fullscreen(GdBool enable) {
 	platformMgr->set_window_fullscreen(enable);
 }
+
 static void gdextension_spx_platform_is_window_fullscreen(GdBool *ret_val) {
 	*ret_val = platformMgr->is_window_fullscreen();
 }
+
 static void gdextension_spx_platform_set_debug_mode(GdBool enable) {
 	platformMgr->set_debug_mode(enable);
 }
+
 static void gdextension_spx_platform_is_debug_mode(GdBool *ret_val) {
 	*ret_val = platformMgr->is_debug_mode();
 }
+
 static void gdextension_spx_platform_get_time_scale(GdFloat *ret_val) {
 	*ret_val = platformMgr->get_time_scale();
 }
+
 static void gdextension_spx_platform_set_time_scale(GdFloat time_scale) {
 	platformMgr->set_time_scale(time_scale);
 }
+
 static void gdextension_spx_platform_get_max_fps(GdInt *ret_val) {
 	*ret_val = platformMgr->get_max_fps();
 }
+
 static void gdextension_spx_platform_set_max_fps(GdInt fps) {
 	platformMgr->set_max_fps(fps);
 }
+
 static void gdextension_spx_platform_get_persistant_data_dir(GdString *ret_val) {
 	*ret_val = platformMgr->get_persistant_data_dir();
 }
+
 static void gdextension_spx_platform_set_persistant_data_dir(GdString path) {
 	platformMgr->set_persistant_data_dir(path);
 }
+
 static void gdextension_spx_platform_is_in_persistant_data_dir(GdString path, GdBool *ret_val) {
 	*ret_val = platformMgr->is_in_persistant_data_dir(path);
 }
+
 static void gdextension_spx_res_create_animation(GdString p_sprite_type, GdString p_anim_name, GdString p_json_ctx, GdInt fps, GdBool is_atlas) {
 	resMgr->create_animation(p_sprite_type, p_anim_name, p_json_ctx, fps, is_atlas);
 }
+
 static void gdextension_spx_res_set_load_mode(GdBool is_direct_mode) {
 	resMgr->set_load_mode(is_direct_mode);
 }
+
 static void gdextension_spx_res_get_load_mode(GdBool *ret_val) {
 	*ret_val = resMgr->get_load_mode();
 }
+
 static void gdextension_spx_res_get_bound_from_alpha(GdString p_path, GdRect2 *ret_val) {
 	*ret_val = resMgr->get_bound_from_alpha(p_path);
 }
+
 static void gdextension_spx_res_get_image_size(GdString p_path, GdVec2 *ret_val) {
 	*ret_val = resMgr->get_image_size(p_path);
 }
+
 static void gdextension_spx_res_read_all_text(GdString p_path, GdString *ret_val) {
 	*ret_val = resMgr->read_all_text(p_path);
 }
+
 static void gdextension_spx_res_has_file(GdString p_path, GdBool *ret_val) {
 	*ret_val = resMgr->has_file(p_path);
 }
+
 static void gdextension_spx_res_reload_texture(GdString path) {
 	resMgr->reload_texture(path);
 }
+
 static void gdextension_spx_res_free_str(GdString str) {
 	resMgr->free_str(str);
 }
+
 static void gdextension_spx_res_set_default_font(GdString font_path) {
 	resMgr->set_default_font(font_path);
 }
+
 static void gdextension_spx_res_register_svg_font_face(GdString font_path, GdString family) {
 	resMgr->register_svg_font_face(font_path, family);
 }
+
 static void gdextension_spx_scene_change_scene_to_file(GdString path) {
 	sceneMgr->change_scene_to_file(path);
 }
+
 static void gdextension_spx_scene_destroy_all_sprites() {
 	sceneMgr->destroy_all_sprites();
 }
+
 static void gdextension_spx_scene_reload_current_scene(GdInt *ret_val) {
 	*ret_val = sceneMgr->reload_current_scene();
 }
+
 static void gdextension_spx_scene_unload_current_scene() {
 	sceneMgr->unload_current_scene();
 }
+
 static void gdextension_spx_scene_clear_pure_sprites() {
 	sceneMgr->clear_pure_sprites();
 }
+
 static void gdextension_spx_scene_create_pure_sprite(GdString texture_path, GdVec2 pos, GdInt zindex) {
 	sceneMgr->create_pure_sprite(texture_path, pos, zindex);
 }
+
 static void gdextension_spx_scene_destroy_pure_sprite(GdObj id) {
 	sceneMgr->destroy_pure_sprite(id);
 }
+
 static void gdextension_spx_scene_create_render_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot, GdObj *ret_val) {
 	*ret_val = sceneMgr->create_render_sprite(texture_path, pos, degree, scale, zindex, pivot);
 }
+
 static void gdextension_spx_scene_create_static_sprite(GdString texture_path, GdVec2 pos, GdFloat degree, GdVec2 scale, GdInt zindex, GdVec2 pivot, GdInt collider_type, GdVec2 collider_pivot, GdArray collider_params, GdObj *ret_val) {
 	*ret_val = sceneMgr->create_static_sprite(texture_path, pos, degree, scale, zindex, pivot, collider_type, collider_pivot, collider_params);
 }
+
 static void gdextension_spx_sprite_set_dont_destroy_on_load(GdObj obj) {
 	spriteMgr->set_dont_destroy_on_load(obj);
 }
+
 static void gdextension_spx_sprite_set_process(GdObj obj, GdBool is_on) {
 	spriteMgr->set_process(obj, is_on);
 }
+
 static void gdextension_spx_sprite_set_physic_process(GdObj obj, GdBool is_on) {
 	spriteMgr->set_physic_process(obj, is_on);
 }
+
 static void gdextension_spx_sprite_set_type_name(GdObj obj, GdString type_name) {
 	spriteMgr->set_type_name(obj, type_name);
 }
+
 static void gdextension_spx_sprite_set_pivot(GdObj obj, GdVec2 pivot) {
 	spriteMgr->set_pivot(obj, pivot);
 }
+
 static void gdextension_spx_sprite_get_pivot(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_pivot(obj);
 }
+
 static void gdextension_spx_sprite_set_child_position(GdObj obj, GdString path, GdVec2 pos) {
 	spriteMgr->set_child_position(obj, path, pos);
 }
+
 static void gdextension_spx_sprite_get_child_position(GdObj obj, GdString path, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_child_position(obj, path);
 }
+
 static void gdextension_spx_sprite_set_child_rotation(GdObj obj, GdString path, GdFloat rot) {
 	spriteMgr->set_child_rotation(obj, path, rot);
 }
+
 static void gdextension_spx_sprite_get_child_rotation(GdObj obj, GdString path, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_child_rotation(obj, path);
 }
+
 static void gdextension_spx_sprite_set_child_scale(GdObj obj, GdString path, GdVec2 scale) {
 	spriteMgr->set_child_scale(obj, path, scale);
 }
+
 static void gdextension_spx_sprite_get_child_scale(GdObj obj, GdString path, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_child_scale(obj, path);
 }
+
 static void gdextension_spx_sprite_check_collision(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision(obj, target, is_src_trigger, is_dst_trigger);
 }
+
 static void gdextension_spx_sprite_check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision_with_point(obj, point, is_trigger);
 }
+
 static void gdextension_spx_sprite_set_debug_collision_visible(GdObj obj, GdBool visible) {
 	spriteMgr->set_debug_collision_visible(obj, visible);
 }
+
 static void gdextension_spx_sprite_is_debug_collision_visible(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_debug_collision_visible(obj);
 }
+
 static void gdextension_spx_sprite_create_backdrop(GdString path, GdObj *ret_val) {
 	*ret_val = spriteMgr->create_backdrop(path);
 }
+
 static void gdextension_spx_sprite_create_sprite(GdString path, GdVec2 pos, GdObj *ret_val) {
 	*ret_val = spriteMgr->create_sprite(path, pos);
 }
+
 static void gdextension_spx_sprite_create_bare_sprite(GdVec2 pos, GdObj *ret_val) {
 	*ret_val = spriteMgr->create_bare_sprite(pos);
 }
+
 static void gdextension_spx_sprite_clone_sprite(GdObj obj, GdObj *ret_val) {
 	*ret_val = spriteMgr->clone_sprite(obj);
 }
+
 static void gdextension_spx_sprite_destroy_sprite(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->destroy_sprite(obj);
 }
+
 static void gdextension_spx_sprite_is_sprite_alive(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_sprite_alive(obj);
 }
+
 static void gdextension_spx_sprite_set_position(GdObj obj, GdVec2 pos) {
 	spriteMgr->set_position(obj, pos);
 }
+
 static void gdextension_spx_sprite_set_transform(GdObj obj, GdVec2 pos, GdFloat rot, GdVec2 scale, GdBool visible, GdVec2 pivot) {
 	spriteMgr->set_transform(obj, pos, rot, scale, visible, pivot);
 }
+
 static void gdextension_spx_sprite_get_position(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_position(obj);
 }
+
 static void gdextension_spx_sprite_set_rotation(GdObj obj, GdFloat rot) {
 	spriteMgr->set_rotation(obj, rot);
 }
+
 static void gdextension_spx_sprite_get_rotation(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_rotation(obj);
 }
+
 static void gdextension_spx_sprite_set_scale(GdObj obj, GdVec2 scale) {
 	spriteMgr->set_scale(obj, scale);
 }
+
 static void gdextension_spx_sprite_get_scale(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_scale(obj);
 }
+
 static void gdextension_spx_sprite_set_render_scale(GdObj obj, GdVec2 scale) {
 	spriteMgr->set_render_scale(obj, scale);
 }
+
 static void gdextension_spx_sprite_get_render_scale(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_render_scale(obj);
 }
+
 static void gdextension_spx_sprite_set_color(GdObj obj, GdColor color) {
 	spriteMgr->set_color(obj, color);
 }
+
 static void gdextension_spx_sprite_get_color(GdObj obj, GdColor *ret_val) {
 	*ret_val = spriteMgr->get_color(obj);
 }
+
 static void gdextension_spx_sprite_set_material_shader(GdObj obj, GdString path) {
 	spriteMgr->set_material_shader(obj, path);
 }
+
 static void gdextension_spx_sprite_get_material_shader(GdObj obj, GdString *ret_val) {
 	*ret_val = spriteMgr->get_material_shader(obj);
 }
+
 static void gdextension_spx_sprite_set_material_params(GdObj obj, GdString effect, GdFloat amount) {
 	spriteMgr->set_material_params(obj, effect, amount);
 }
+
 static void gdextension_spx_sprite_get_material_params(GdObj obj, GdString effect, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_material_params(obj, effect);
 }
+
 static void gdextension_spx_sprite_set_material_params_vec(GdObj obj, GdString effect, GdFloat x, GdFloat y, GdFloat z, GdFloat w) {
 	spriteMgr->set_material_params_vec(obj, effect, x, y, z, w);
 }
+
 static void gdextension_spx_sprite_set_material_params_vec4(GdObj obj, GdString effect, GdVec4 vec4) {
 	spriteMgr->set_material_params_vec4(obj, effect, vec4);
 }
+
 static void gdextension_spx_sprite_get_material_params_vec4(GdObj obj, GdString effect, GdVec4 *ret_val) {
 	*ret_val = spriteMgr->get_material_params_vec4(obj, effect);
 }
+
 static void gdextension_spx_sprite_set_material_params_color(GdObj obj, GdString effect, GdColor color) {
 	spriteMgr->set_material_params_color(obj, effect, color);
 }
+
 static void gdextension_spx_sprite_get_material_params_color(GdObj obj, GdString effect, GdColor *ret_val) {
 	*ret_val = spriteMgr->get_material_params_color(obj, effect);
 }
+
 static void gdextension_spx_sprite_set_texture_atlas(GdObj obj, GdString path, GdRect2 rect2) {
 	spriteMgr->set_texture_atlas(obj, path, rect2);
 }
+
 static void gdextension_spx_sprite_set_texture(GdObj obj, GdString path) {
 	spriteMgr->set_texture(obj, path);
 }
+
 static void gdextension_spx_sprite_set_texture_atlas_direct(GdObj obj, GdString path, GdRect2 rect2) {
 	spriteMgr->set_texture_atlas_direct(obj, path, rect2);
 }
+
 static void gdextension_spx_sprite_set_texture_direct(GdObj obj, GdString path) {
 	spriteMgr->set_texture_direct(obj, path);
 }
+
 static void gdextension_spx_sprite_get_texture(GdObj obj, GdString *ret_val) {
 	*ret_val = spriteMgr->get_texture(obj);
 }
+
 static void gdextension_spx_sprite_set_visible(GdObj obj, GdBool visible) {
 	spriteMgr->set_visible(obj, visible);
 }
+
 static void gdextension_spx_sprite_get_visible(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->get_visible(obj);
 }
+
 static void gdextension_spx_sprite_get_z_index(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_z_index(obj);
 }
+
 static void gdextension_spx_sprite_set_z_index(GdObj obj, GdInt z) {
 	spriteMgr->set_z_index(obj, z);
 }
+
 static void gdextension_spx_sprite_play_anim(GdObj obj, GdString p_name, GdFloat p_speed, GdBool isLoop, GdBool p_revert) {
 	spriteMgr->play_anim(obj, p_name, p_speed, isLoop, p_revert);
 }
+
 static void gdextension_spx_sprite_play_backwards_anim(GdObj obj, GdString p_name) {
 	spriteMgr->play_backwards_anim(obj, p_name);
 }
+
 static void gdextension_spx_sprite_pause_anim(GdObj obj) {
 	spriteMgr->pause_anim(obj);
 }
+
 static void gdextension_spx_sprite_stop_anim(GdObj obj) {
 	spriteMgr->stop_anim(obj);
 }
+
 static void gdextension_spx_sprite_is_playing_anim(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_playing_anim(obj);
 }
+
 static void gdextension_spx_sprite_set_anim(GdObj obj, GdString p_name) {
 	spriteMgr->set_anim(obj, p_name);
 }
+
 static void gdextension_spx_sprite_get_anim(GdObj obj, GdString *ret_val) {
 	*ret_val = spriteMgr->get_anim(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_frame(GdObj obj, GdInt p_frame) {
 	spriteMgr->set_anim_frame(obj, p_frame);
 }
+
 static void gdextension_spx_sprite_get_anim_frame(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_anim_frame(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_speed_scale(GdObj obj, GdFloat p_speed_scale) {
 	spriteMgr->set_anim_speed_scale(obj, p_speed_scale);
 }
+
 static void gdextension_spx_sprite_get_anim_speed_scale(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_anim_speed_scale(obj);
 }
+
 static void gdextension_spx_sprite_get_anim_playing_speed(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_anim_playing_speed(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_centered(GdObj obj, GdBool p_center) {
 	spriteMgr->set_anim_centered(obj, p_center);
 }
+
 static void gdextension_spx_sprite_is_anim_centered(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_anim_centered(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_offset(GdObj obj, GdVec2 p_offset) {
 	spriteMgr->set_anim_offset(obj, p_offset);
 }
+
 static void gdextension_spx_sprite_get_anim_offset(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_anim_offset(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_flip_h(GdObj obj, GdBool p_flip) {
 	spriteMgr->set_anim_flip_h(obj, p_flip);
 }
+
 static void gdextension_spx_sprite_is_anim_flipped_h(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_anim_flipped_h(obj);
 }
+
 static void gdextension_spx_sprite_set_anim_flip_v(GdObj obj, GdBool p_flip) {
 	spriteMgr->set_anim_flip_v(obj, p_flip);
 }
+
 static void gdextension_spx_sprite_is_anim_flipped_v(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_anim_flipped_v(obj);
 }
+
 static void gdextension_spx_sprite_get_current_anim_name(GdObj obj, GdString *ret_val) {
 	*ret_val = spriteMgr->get_current_anim_name(obj);
 }
+
 static void gdextension_spx_sprite_set_velocity(GdObj obj, GdVec2 velocity) {
 	spriteMgr->set_velocity(obj, velocity);
 }
+
 static void gdextension_spx_sprite_get_velocity(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_velocity(obj);
 }
+
 static void gdextension_spx_sprite_is_on_floor(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_floor(obj);
 }
+
 static void gdextension_spx_sprite_is_on_floor_only(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_floor_only(obj);
 }
+
 static void gdextension_spx_sprite_is_on_wall(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_wall(obj);
 }
+
 static void gdextension_spx_sprite_is_on_wall_only(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_wall_only(obj);
 }
+
 static void gdextension_spx_sprite_is_on_ceiling(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_ceiling(obj);
 }
+
 static void gdextension_spx_sprite_is_on_ceiling_only(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_on_ceiling_only(obj);
 }
+
 static void gdextension_spx_sprite_get_last_motion(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_last_motion(obj);
 }
+
 static void gdextension_spx_sprite_get_position_delta(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_position_delta(obj);
 }
+
 static void gdextension_spx_sprite_get_floor_normal(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_floor_normal(obj);
 }
+
 static void gdextension_spx_sprite_get_wall_normal(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_wall_normal(obj);
 }
+
 static void gdextension_spx_sprite_get_real_velocity(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = spriteMgr->get_real_velocity(obj);
 }
+
 static void gdextension_spx_sprite_move_and_slide(GdObj obj) {
 	spriteMgr->move_and_slide(obj);
 }
+
 static void gdextension_spx_sprite_set_gravity(GdObj obj, GdFloat gravity) {
 	spriteMgr->set_gravity(obj, gravity);
 }
+
 static void gdextension_spx_sprite_get_gravity(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_gravity(obj);
 }
+
 static void gdextension_spx_sprite_set_mass(GdObj obj, GdFloat mass) {
 	spriteMgr->set_mass(obj, mass);
 }
+
 static void gdextension_spx_sprite_get_mass(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_mass(obj);
 }
+
 static void gdextension_spx_sprite_add_force(GdObj obj, GdVec2 force) {
 	spriteMgr->add_force(obj, force);
 }
+
 static void gdextension_spx_sprite_add_impulse(GdObj obj, GdVec2 impulse) {
 	spriteMgr->add_impulse(obj, impulse);
 }
+
 static void gdextension_spx_sprite_set_physics_mode(GdObj obj, GdInt mode) {
 	spriteMgr->set_physics_mode(obj, mode);
 }
+
 static void gdextension_spx_sprite_get_physics_mode(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_physics_mode(obj);
 }
+
 static void gdextension_spx_sprite_set_use_gravity(GdObj obj, GdBool enabled) {
 	spriteMgr->set_use_gravity(obj, enabled);
 }
+
 static void gdextension_spx_sprite_is_use_gravity(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_use_gravity(obj);
 }
+
 static void gdextension_spx_sprite_set_gravity_scale(GdObj obj, GdFloat scale) {
 	spriteMgr->set_gravity_scale(obj, scale);
 }
+
 static void gdextension_spx_sprite_get_gravity_scale(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_gravity_scale(obj);
 }
+
 static void gdextension_spx_sprite_set_drag(GdObj obj, GdFloat drag) {
 	spriteMgr->set_drag(obj, drag);
 }
+
 static void gdextension_spx_sprite_get_drag(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_drag(obj);
 }
+
 static void gdextension_spx_sprite_set_friction(GdObj obj, GdFloat friction) {
 	spriteMgr->set_friction(obj, friction);
 }
+
 static void gdextension_spx_sprite_get_friction(GdObj obj, GdFloat *ret_val) {
 	*ret_val = spriteMgr->get_friction(obj);
 }
+
 static void gdextension_spx_sprite_set_collision_layer(GdObj obj, GdInt layer) {
 	spriteMgr->set_collision_layer(obj, layer);
 }
+
 static void gdextension_spx_sprite_get_collision_layer(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_collision_layer(obj);
 }
+
 static void gdextension_spx_sprite_set_collision_mask(GdObj obj, GdInt mask) {
 	spriteMgr->set_collision_mask(obj, mask);
 }
+
 static void gdextension_spx_sprite_get_collision_mask(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_collision_mask(obj);
 }
+
 static void gdextension_spx_sprite_set_trigger_layer(GdObj obj, GdInt layer) {
 	spriteMgr->set_trigger_layer(obj, layer);
 }
+
 static void gdextension_spx_sprite_get_trigger_layer(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_trigger_layer(obj);
 }
+
 static void gdextension_spx_sprite_set_trigger_mask(GdObj obj, GdInt mask) {
 	spriteMgr->set_trigger_mask(obj, mask);
 }
+
 static void gdextension_spx_sprite_get_trigger_mask(GdObj obj, GdInt *ret_val) {
 	*ret_val = spriteMgr->get_trigger_mask(obj);
 }
+
 static void gdextension_spx_sprite_set_collider_rect(GdObj obj, GdVec2 center, GdVec2 size) {
 	spriteMgr->set_collider_rect(obj, center, size);
 }
+
 static void gdextension_spx_sprite_set_collider_circle(GdObj obj, GdVec2 center, GdFloat radius) {
 	spriteMgr->set_collider_circle(obj, center, radius);
 }
+
 static void gdextension_spx_sprite_set_collider_capsule(GdObj obj, GdVec2 center, GdVec2 size) {
 	spriteMgr->set_collider_capsule(obj, center, size);
 }
+
 static void gdextension_spx_sprite_set_collider_polygon(GdObj obj, GdVec2 center, GdArray points) {
 	spriteMgr->set_collider_polygon(obj, center, points);
 }
+
 static void gdextension_spx_sprite_set_collision_enabled(GdObj obj, GdBool enabled) {
 	spriteMgr->set_collision_enabled(obj, enabled);
 }
+
 static void gdextension_spx_sprite_is_collision_enabled(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_collision_enabled(obj);
 }
+
 static void gdextension_spx_sprite_set_trigger_rect(GdObj obj, GdVec2 center, GdVec2 size) {
 	spriteMgr->set_trigger_rect(obj, center, size);
 }
+
 static void gdextension_spx_sprite_set_trigger_circle(GdObj obj, GdVec2 center, GdFloat radius) {
 	spriteMgr->set_trigger_circle(obj, center, radius);
 }
+
 static void gdextension_spx_sprite_set_trigger_capsule(GdObj obj, GdVec2 center, GdVec2 size) {
 	spriteMgr->set_trigger_capsule(obj, center, size);
 }
+
 static void gdextension_spx_sprite_set_trigger_polygon(GdObj obj, GdVec2 center, GdArray points) {
 	spriteMgr->set_trigger_polygon(obj, center, points);
 }
+
 static void gdextension_spx_sprite_set_trigger_enabled(GdObj obj, GdBool trigger) {
 	spriteMgr->set_trigger_enabled(obj, trigger);
 }
+
 static void gdextension_spx_sprite_is_trigger_enabled(GdObj obj, GdBool *ret_val) {
 	*ret_val = spriteMgr->is_trigger_enabled(obj);
 }
+
 static void gdextension_spx_sprite_check_collision_by_color(GdObj obj, GdColor color, GdFloat color_threshold, GdFloat alpha_threshold, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision_by_color(obj, color, color_threshold, alpha_threshold);
 }
+
 static void gdextension_spx_sprite_check_collision_by_colors(GdObj obj, GdColor sprite_color, GdColor target_color, GdFloat color_threshold, GdFloat alpha_threshold, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision_by_colors(obj, sprite_color, target_color, color_threshold, alpha_threshold);
 }
+
 static void gdextension_spx_sprite_check_collision_by_alpha(GdObj obj, GdFloat alpha_threshold, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision_by_alpha(obj, alpha_threshold);
 }
+
 static void gdextension_spx_sprite_check_collision_with_sprite(GdObj obj, GdObj obj_b, GdFloat alpha_threshold, GdBool use_pixel_perfect, GdBool *ret_val) {
 	*ret_val = spriteMgr->check_collision_with_sprite(obj, obj_b, alpha_threshold, use_pixel_perfect);
 }
+
 static void gdextension_spx_sprite_set_pixel_collision_sampling_step(GdInt step) {
 	spriteMgr->set_pixel_collision_sampling_step(step);
 }
+
 static void gdextension_spx_sprite_get_pixel_collision_sampling_step(GdInt *ret_val) {
 	*ret_val = spriteMgr->get_pixel_collision_sampling_step();
 }
+
 static void gdextension_spx_sprite_batch_update_transforms(const float *buffer_data, int len) {
 	spriteMgr->batch_update_transforms(buffer_data, len);
 }
+
 static void gdextension_spx_sprite_batch_update_visuals(const float *buffer_data, int len) {
 	spriteMgr->batch_update_visuals(buffer_data, len);
 }
-static void gdextension_spx_sprite_batch_retrieve_positions(GdArray objs, GdArray *ret_val) {
-	*ret_val = spriteMgr->batch_retrieve_positions(objs);
+
+static void gdextension_spx_sprite_batch_update_physics(const float *buffer_data, int len) {
+	spriteMgr->batch_update_physics(buffer_data, len);
 }
+
 static void gdextension_spx_tilemap_open_draw_tiles_with_size(GdInt tile_size) {
 	tilemapMgr->open_draw_tiles_with_size(tile_size);
 }
+
 static void gdextension_spx_tilemap_open_draw_tiles() {
 	tilemapMgr->open_draw_tiles();
 }
+
 static void gdextension_spx_tilemap_set_layer_index(GdInt index) {
 	tilemapMgr->set_layer_index(index);
 }
+
 static void gdextension_spx_tilemap_set_tile(GdString texture_path, GdBool with_collision) {
 	tilemapMgr->set_tile(texture_path, with_collision);
 }
+
 static void gdextension_spx_tilemap_set_tile_with_collision_info(GdString texture_path, GdArray collision_points) {
 	tilemapMgr->set_tile_with_collision_info(texture_path, collision_points);
 }
+
 static void gdextension_spx_tilemap_set_layer_offset(GdInt index, GdVec2 offset) {
 	tilemapMgr->set_layer_offset(index, offset);
 }
+
 static void gdextension_spx_tilemap_get_layer_offset(GdInt index, GdVec2 *ret_val) {
 	*ret_val = tilemapMgr->get_layer_offset(index);
 }
+
 static void gdextension_spx_tilemap_place_tiles(GdArray positions, GdString texture_path) {
 	tilemapMgr->place_tiles(positions, texture_path);
 }
+
 static void gdextension_spx_tilemap_place_tiles_with_layer(GdArray positions, GdString texture_path, GdInt layer_index) {
 	tilemapMgr->place_tiles_with_layer(positions, texture_path, layer_index);
 }
+
 static void gdextension_spx_tilemap_place_tile(GdVec2 pos, GdString texture_path) {
 	tilemapMgr->place_tile(pos, texture_path);
 }
+
 static void gdextension_spx_tilemap_place_tile_with_layer(GdVec2 pos, GdString texture_path, GdInt layer_index) {
 	tilemapMgr->place_tile_with_layer(pos, texture_path, layer_index);
 }
+
 static void gdextension_spx_tilemap_erase_tile(GdVec2 pos) {
 	tilemapMgr->erase_tile(pos);
 }
+
 static void gdextension_spx_tilemap_erase_tile_with_layer(GdVec2 pos, GdInt layer_index) {
 	tilemapMgr->erase_tile_with_layer(pos, layer_index);
 }
+
 static void gdextension_spx_tilemap_get_tile(GdVec2 pos, GdString *ret_val) {
 	*ret_val = tilemapMgr->get_tile(pos);
 }
+
 static void gdextension_spx_tilemap_get_tile_with_layer(GdVec2 pos, GdInt layer_index, GdString *ret_val) {
 	*ret_val = tilemapMgr->get_tile_with_layer(pos, layer_index);
 }
+
 static void gdextension_spx_tilemap_close_draw_tiles() {
 	tilemapMgr->close_draw_tiles();
 }
+
 static void gdextension_spx_tilemap_exit_tilemap_editor_mode() {
 	tilemapMgr->exit_tilemap_editor_mode();
 }
+
 static void gdextension_spx_tilemapparser_load_tilemap(GdString json_path) {
 	tilemapparserMgr->load_tilemap(json_path);
 }
+
 static void gdextension_spx_tilemapparser_unload_tilemap(GdString name) {
 	tilemapparserMgr->unload_tilemap(name);
 }
+
 static void gdextension_spx_tilemapparser_destroy_all_tilemaps() {
 	tilemapparserMgr->destroy_all_tilemaps();
 }
+
 static void gdextension_spx_tilemapparser_has_tilemap(GdString name, GdBool *ret_val) {
 	*ret_val = tilemapparserMgr->has_tilemap(name);
 }
+
 static void gdextension_spx_tilemapparser_get_tilemap_layer_count(GdString name, GdInt *ret_val) {
 	*ret_val = tilemapparserMgr->get_tilemap_layer_count(name);
 }
+
 static void gdextension_spx_ui_bind_node(GdObj obj, GdString rel_path, GdObj *ret_val) {
 	*ret_val = uiMgr->bind_node(obj, rel_path);
 }
+
 static void gdextension_spx_ui_create_node(GdString path, GdObj *ret_val) {
 	*ret_val = uiMgr->create_node(path);
 }
+
 static void gdextension_spx_ui_create_button(GdString path, GdString text, GdObj *ret_val) {
 	*ret_val = uiMgr->create_button(path, text);
 }
+
 static void gdextension_spx_ui_create_label(GdString path, GdString text, GdObj *ret_val) {
 	*ret_val = uiMgr->create_label(path, text);
 }
+
 static void gdextension_spx_ui_create_image(GdString path, GdObj *ret_val) {
 	*ret_val = uiMgr->create_image(path);
 }
+
 static void gdextension_spx_ui_create_toggle(GdString path, GdBool value, GdObj *ret_val) {
 	*ret_val = uiMgr->create_toggle(path, value);
 }
+
 static void gdextension_spx_ui_create_slider(GdString path, GdFloat value, GdObj *ret_val) {
 	*ret_val = uiMgr->create_slider(path, value);
 }
+
 static void gdextension_spx_ui_create_input(GdString path, GdString text, GdObj *ret_val) {
 	*ret_val = uiMgr->create_input(path, text);
 }
+
 static void gdextension_spx_ui_destroy_node(GdObj obj, GdBool *ret_val) {
 	*ret_val = uiMgr->destroy_node(obj);
 }
+
 static void gdextension_spx_ui_get_type(GdObj obj, GdInt *ret_val) {
 	*ret_val = uiMgr->get_type(obj);
 }
+
 static void gdextension_spx_ui_set_text(GdObj obj, GdString text) {
 	uiMgr->set_text(obj, text);
 }
+
 static void gdextension_spx_ui_get_text(GdObj obj, GdString *ret_val) {
 	*ret_val = uiMgr->get_text(obj);
 }
+
 static void gdextension_spx_ui_set_texture(GdObj obj, GdString path) {
 	uiMgr->set_texture(obj, path);
 }
+
 static void gdextension_spx_ui_get_texture(GdObj obj, GdString *ret_val) {
 	*ret_val = uiMgr->get_texture(obj);
 }
+
 static void gdextension_spx_ui_set_color(GdObj obj, GdColor color) {
 	uiMgr->set_color(obj, color);
 }
+
 static void gdextension_spx_ui_get_color(GdObj obj, GdColor *ret_val) {
 	*ret_val = uiMgr->get_color(obj);
 }
+
 static void gdextension_spx_ui_set_font_size(GdObj obj, GdInt size) {
 	uiMgr->set_font_size(obj, size);
 }
+
 static void gdextension_spx_ui_get_font_size(GdObj obj, GdInt *ret_val) {
 	*ret_val = uiMgr->get_font_size(obj);
 }
+
 static void gdextension_spx_ui_set_visible(GdObj obj, GdBool visible) {
 	uiMgr->set_visible(obj, visible);
 }
+
 static void gdextension_spx_ui_get_visible(GdObj obj, GdBool *ret_val) {
 	*ret_val = uiMgr->get_visible(obj);
 }
+
 static void gdextension_spx_ui_set_interactable(GdObj obj, GdBool interactable) {
 	uiMgr->set_interactable(obj, interactable);
 }
+
 static void gdextension_spx_ui_get_interactable(GdObj obj, GdBool *ret_val) {
 	*ret_val = uiMgr->get_interactable(obj);
 }
+
 static void gdextension_spx_ui_set_rect(GdObj obj, GdRect2 rect) {
 	uiMgr->set_rect(obj, rect);
 }
+
 static void gdextension_spx_ui_get_rect(GdObj obj, GdRect2 *ret_val) {
 	*ret_val = uiMgr->get_rect(obj);
 }
+
 static void gdextension_spx_ui_get_layout_direction(GdObj obj, GdInt *ret_val) {
 	*ret_val = uiMgr->get_layout_direction(obj);
 }
+
 static void gdextension_spx_ui_set_layout_direction(GdObj obj, GdInt value) {
 	uiMgr->set_layout_direction(obj, value);
 }
+
 static void gdextension_spx_ui_get_layout_mode(GdObj obj, GdInt *ret_val) {
 	*ret_val = uiMgr->get_layout_mode(obj);
 }
+
 static void gdextension_spx_ui_set_layout_mode(GdObj obj, GdInt value) {
 	uiMgr->set_layout_mode(obj, value);
 }
+
 static void gdextension_spx_ui_get_anchors_preset(GdObj obj, GdInt *ret_val) {
 	*ret_val = uiMgr->get_anchors_preset(obj);
 }
+
 static void gdextension_spx_ui_set_anchors_preset(GdObj obj, GdInt value) {
 	uiMgr->set_anchors_preset(obj, value);
 }
+
 static void gdextension_spx_ui_get_scale(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = uiMgr->get_scale(obj);
 }
+
 static void gdextension_spx_ui_set_scale(GdObj obj, GdVec2 value) {
 	uiMgr->set_scale(obj, value);
 }
+
 static void gdextension_spx_ui_get_position(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = uiMgr->get_position(obj);
 }
+
 static void gdextension_spx_ui_set_position(GdObj obj, GdVec2 value) {
 	uiMgr->set_position(obj, value);
 }
+
 static void gdextension_spx_ui_get_size(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = uiMgr->get_size(obj);
 }
+
 static void gdextension_spx_ui_set_size(GdObj obj, GdVec2 value) {
 	uiMgr->set_size(obj, value);
 }
+
 static void gdextension_spx_ui_get_global_position(GdObj obj, GdVec2 *ret_val) {
 	*ret_val = uiMgr->get_global_position(obj);
 }
+
 static void gdextension_spx_ui_set_global_position(GdObj obj, GdVec2 value) {
 	uiMgr->set_global_position(obj, value);
 }
+
 static void gdextension_spx_ui_get_rotation(GdObj obj, GdFloat *ret_val) {
 	*ret_val = uiMgr->get_rotation(obj);
 }
+
 static void gdextension_spx_ui_set_rotation(GdObj obj, GdFloat value) {
 	uiMgr->set_rotation(obj, value);
 }
+
 static void gdextension_spx_ui_get_flip(GdObj obj, GdBool horizontal, GdBool *ret_val) {
 	*ret_val = uiMgr->get_flip(obj, horizontal);
 }
+
 static void gdextension_spx_ui_set_flip(GdObj obj, GdBool horizontal, GdBool is_flip) {
 	uiMgr->set_flip(obj, horizontal, is_flip);
 }
+
+static void gdextension_spx_sprite_batch_retrieve_positions(GdArray objs, GdArray *ret_val) {
+	if (!objs) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	int count = objs->size;
+	if (count == 0) {
+		*ret_val = nullptr;
+		return;
+	}
+	if (count > 0x7fffffff / 2) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	int out_len = count * 2;
+	GdArray result = SpxBaseMgr::create_array(GD_ARRAY_TYPE_FLOAT, out_len);
+	if (!result) {
+		*ret_val = nullptr;
+		return;
+	}
+
+	const GdObj *input = SpxBaseMgr::get_array<GdObj>(objs, 0);
+	float *out = SpxBaseMgr::get_array<float>(result, 0);
+	if (!input || !out) {
+		SpxBaseMgr::free_array(result);
+		*ret_val = nullptr;
+		return;
+	}
+
+	spriteMgr->batch_retrieve_positions(input, count, out, out_len);
+	*ret_val = result;
+}
+
 
 void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_global_register_callbacks);
@@ -1071,6 +1450,12 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_pressed);
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_just_pressed);
 	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_just_released);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_register_action);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_get_axis_id);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_pressed_id);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_just_pressed_id);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_is_action_just_released_id);
+	REGISTER_SPX_INTERFACE_FUNC(spx_input_write_snapshot);
 	REGISTER_SPX_INTERFACE_FUNC(spx_navigation_setup_path_finder_with_size);
 	REGISTER_SPX_INTERFACE_FUNC(spx_navigation_setup_path_finder);
 	REGISTER_SPX_INTERFACE_FUNC(spx_navigation_set_obstacle);
@@ -1277,7 +1662,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_get_pixel_collision_sampling_step);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_batch_update_transforms);
 	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_batch_update_visuals);
-	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_batch_retrieve_positions);
+	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_batch_update_physics);
 	REGISTER_SPX_INTERFACE_FUNC(spx_tilemap_open_draw_tiles_with_size);
 	REGISTER_SPX_INTERFACE_FUNC(spx_tilemap_open_draw_tiles);
 	REGISTER_SPX_INTERFACE_FUNC(spx_tilemap_set_layer_index);
@@ -1342,4 +1727,5 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_ui_set_rotation);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ui_get_flip);
 	REGISTER_SPX_INTERFACE_FUNC(spx_ui_set_flip);
+	REGISTER_SPX_INTERFACE_FUNC(spx_sprite_batch_retrieve_positions);
 }

--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -1370,7 +1370,7 @@ static void gdextension_spx_sprite_batch_retrieve_positions(GdArray objs, GdArra
 	}
 
 	int count = objs->size;
-	if (count == 0) {
+	if (count <= 0) {
 		*ret_val = nullptr;
 		return;
 	}

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -270,6 +270,12 @@ typedef void (*GDExtensionSpxInputGetAxis)(GdString neg_action, GdString pos_act
 typedef void (*GDExtensionSpxInputIsActionPressed)(GdString action, GdBool *ret_value);
 typedef void (*GDExtensionSpxInputIsActionJustPressed)(GdString action, GdBool *ret_value);
 typedef void (*GDExtensionSpxInputIsActionJustReleased)(GdString action, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputRegisterAction)(GdString action, GdInt *ret_value);
+typedef void (*GDExtensionSpxInputGetAxisId)(GdInt neg_action_id, GdInt pos_action_id, GdFloat *ret_value);
+typedef void (*GDExtensionSpxInputIsActionPressedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputIsActionJustPressedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputIsActionJustReleasedId)(GdInt action_id, GdBool *ret_value);
+typedef void (*GDExtensionSpxInputWriteSnapshot)(float *out, int len);
 // SpxNavigation
 typedef void (*GDExtensionSpxNavigationSetupPathFinderWithSize)(GdVec2 grid_size, GdVec2 cell_size, GdBool with_jump, GdBool with_debug);
 typedef void (*GDExtensionSpxNavigationSetupPathFinder)(GdBool with_jump);
@@ -483,7 +489,7 @@ typedef void (*GDExtensionSpxSpriteSetPixelCollisionSamplingStep)(GdInt step);
 typedef void (*GDExtensionSpxSpriteGetPixelCollisionSamplingStep)(GdInt *ret_value);
 typedef void (*GDExtensionSpxSpriteBatchUpdateTransforms)(const float *buffer_data, int len);
 typedef void (*GDExtensionSpxSpriteBatchUpdateVisuals)(const float *buffer_data, int len);
-typedef void (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs, GdArray *ret_value);
+typedef void (*GDExtensionSpxSpriteBatchUpdatePhysics)(const float *buffer_data, int len);
 // SpxTilemap
 typedef void (*GDExtensionSpxTilemapOpenDrawTilesWithSize)(GdInt tile_size);
 typedef void (*GDExtensionSpxTilemapOpenDrawTiles)();
@@ -551,6 +557,7 @@ typedef void (*GDExtensionSpxUiGetRotation)(GdObj obj, GdFloat *ret_value);
 typedef void (*GDExtensionSpxUiSetRotation)(GdObj obj, GdFloat value);
 typedef void (*GDExtensionSpxUiGetFlip)(GdObj obj, GdBool horizontal, GdBool *ret_value);
 typedef void (*GDExtensionSpxUiSetFlip)(GdObj obj, GdBool horizontal, GdBool is_flip);
+typedef void (*GDExtensionSpxSpriteBatchRetrievePositions)(GdArray objs, GdArray *ret_value);
 
 
 #ifdef __cplusplus

--- a/modules/spx/spx_input_mgr.cpp
+++ b/modules/spx/spx_input_mgr.cpp
@@ -52,6 +52,8 @@ void SpxInputMgr::on_reset(int reset_code) {
 		input_proxy->queue_free();
 		input_proxy = nullptr;
 	}
+	action_names.clear();
+	action_ids.clear();
 }
 
 // input
@@ -137,7 +139,9 @@ void SpxInputMgr::write_snapshot(float *out, int len) {
 	Input *input = Input::get_singleton();
 	for (int i = (int)MouseButton::LEFT; i <= (int)MouseButton::MIDDLE; i++) {
 		if (input->is_mouse_button_pressed((MouseButton)i)) {
-			mouse_bits |= 1u << i;
+			// Compact the hot-path snapshot to zero-based button lanes:
+			// bit 0 = left, bit 1 = right, bit 2 = middle.
+			mouse_bits |= 1u << (i - (int)MouseButton::LEFT);
 		}
 	}
 

--- a/modules/spx/spx_input_mgr.cpp
+++ b/modules/spx/spx_input_mgr.cpp
@@ -90,3 +90,65 @@ GdBool SpxInputMgr::is_action_just_pressed(GdString action) {
 GdBool SpxInputMgr::is_action_just_released(GdString action) {
 	return Input::get_singleton()->is_action_just_released(SpxStr(action));
 }
+
+GdInt SpxInputMgr::register_action(GdString action) {
+	StringName name(SpxStr(action));
+	if (action_ids.has(name)) {
+		return action_ids[name];
+	}
+
+	GdInt id = action_names.size();
+	action_names.push_back(name);
+	action_ids.insert(name, id);
+	return id;
+}
+
+GdFloat SpxInputMgr::get_axis_id(GdInt neg_action_id, GdInt pos_action_id) {
+	const StringName *neg = get_registered_action(neg_action_id);
+	const StringName *pos = get_registered_action(pos_action_id);
+	if (neg == nullptr || pos == nullptr) {
+		return 0;
+	}
+	return Input::get_singleton()->get_axis(*neg, *pos);
+}
+
+GdBool SpxInputMgr::is_action_pressed_id(GdInt action_id) {
+	const StringName *action = get_registered_action(action_id);
+	return action != nullptr && Input::get_singleton()->is_action_pressed(*action);
+}
+
+GdBool SpxInputMgr::is_action_just_pressed_id(GdInt action_id) {
+	const StringName *action = get_registered_action(action_id);
+	return action != nullptr && Input::get_singleton()->is_action_just_pressed(*action);
+}
+
+GdBool SpxInputMgr::is_action_just_released_id(GdInt action_id) {
+	const StringName *action = get_registered_action(action_id);
+	return action != nullptr && Input::get_singleton()->is_action_just_released(*action);
+}
+
+void SpxInputMgr::write_snapshot(float *out, int len) {
+	if (!out || len < 3) {
+		return;
+	}
+
+	GdVec2 pos = get_global_mouse_pos();
+	uint32_t mouse_bits = 0;
+	Input *input = Input::get_singleton();
+	for (int i = (int)MouseButton::LEFT; i <= (int)MouseButton::MIDDLE; i++) {
+		if (input->is_mouse_button_pressed((MouseButton)i)) {
+			mouse_bits |= 1u << i;
+		}
+	}
+
+	out[0] = pos.x;
+	out[1] = pos.y;
+	out[2] = (float)mouse_bits;
+}
+
+const StringName *SpxInputMgr::get_registered_action(GdInt action_id) const {
+	if (action_id < 0 || action_id >= action_names.size()) {
+		return nullptr;
+	}
+	return &action_names[action_id];
+}

--- a/modules/spx/spx_input_mgr.h
+++ b/modules/spx/spx_input_mgr.h
@@ -31,6 +31,9 @@
 #ifndef SPX_INPUT_MGR_H
 #define SPX_INPUT_MGR_H
 
+#include "core/string/string_name.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/vector.h"
 #include "gdextension_spx_ext.h"
 #include "spx_base_mgr.h"
 #include "spx_input_proxy.h"
@@ -44,6 +47,8 @@ public:
 
 protected:
 	SpxInputProxy *input_proxy = nullptr;
+	Vector<StringName> action_names;
+	HashMap<StringName, GdInt> action_ids;
 
 public:
 	SPX_API GdVec2 get_global_mouse_pos();
@@ -54,6 +59,15 @@ public:
 	SPX_API GdBool is_action_pressed(GdString action);
 	SPX_API GdBool is_action_just_pressed(GdString action);
 	SPX_API GdBool is_action_just_released(GdString action);
+	SPX_API GdInt register_action(GdString action);
+	SPX_API GdFloat get_axis_id(GdInt neg_action_id, GdInt pos_action_id);
+	SPX_API GdBool is_action_pressed_id(GdInt action_id);
+	SPX_API GdBool is_action_just_pressed_id(GdInt action_id);
+	SPX_API GdBool is_action_just_released_id(GdInt action_id);
+	SPX_API void write_snapshot(float *out, int len);
+
+private:
+	const StringName *get_registered_action(GdInt action_id) const;
 };
 
 #endif // SPX_INPUT_MGR_H

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -51,7 +51,29 @@
 #include "spx_scene_mgr.h"
 #include "spx_sprite.h"
 
+#include <cstdint>
+#include <cstring>
+
 #define DEFAULT_COLLISION_ALPHA_THRESHOLD 0.05
+
+enum SpxPhysicsBatchCmd {
+	SPX_PHYSICS_CMD_VELOCITY = 1,
+	SPX_PHYSICS_CMD_GRAVITY = 2,
+	SPX_PHYSICS_CMD_MASS = 3,
+	SPX_PHYSICS_CMD_MODE = 4,
+	SPX_PHYSICS_CMD_USE_GRAVITY = 5,
+	SPX_PHYSICS_CMD_GRAVITY_SCALE = 6,
+	SPX_PHYSICS_CMD_DRAG = 7,
+	SPX_PHYSICS_CMD_FRICTION = 8,
+	SPX_PHYSICS_CMD_COLLISION_LAYER = 9,
+	SPX_PHYSICS_CMD_COLLISION_MASK = 10,
+	SPX_PHYSICS_CMD_TRIGGER_LAYER = 11,
+	SPX_PHYSICS_CMD_TRIGGER_MASK = 12,
+	SPX_PHYSICS_CMD_COLLISION_ENABLED = 13,
+	SPX_PHYSICS_CMD_TRIGGER_ENABLED = 14,
+};
+
+static constexpr int SPX_PHYSICS_BATCH_FIELDS = 6;
 
 StringName SpxSpriteMgr::default_texture_anim;
 
@@ -1288,6 +1310,21 @@ GdVec2 SpxSpriteMgr::get_pivot(GdObj obj) {
 
 namespace {
 
+uint32_t read_u32_lane(float value) {
+	uint32_t bits = 0;
+	std::memcpy(&bits, &value, sizeof(bits));
+	return bits;
+}
+
+GdObj read_gd_obj_lanes(const float *record) {
+	uint64_t low = read_u32_lane(record[1]);
+	uint64_t high = read_u32_lane(record[2]);
+	uint64_t bits = (high << 32) | low;
+	int64_t value = 0;
+	std::memcpy(&value, &bits, sizeof(value));
+	return static_cast<GdObj>(value);
+}
+
 void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len, const char *op_name) {
 	// Buffer format with header: [updateCount, deleteCount, update_data..., delete_ids...]
 	// - Header: [updateCount, deleteCount]
@@ -1307,12 +1344,20 @@ void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, i
 	// Read header using direct array access
 	int update_count = static_cast<int>(buffer_data[0]);
 	int delete_count = static_cast<int>(buffer_data[1]);
+	if (update_count < 0 || delete_count < 0) {
+		print_error(String(op_name) + ": buffer counts must be non-negative.");
+		return;
+	}
 
 	// Validate buffer size
-	int expected_size = HEADER_SIZE + update_count * FIELDS_PER_SPRITE + delete_count;
+	int64_t expected_size = (int64_t)HEADER_SIZE + (int64_t)update_count * FIELDS_PER_SPRITE + delete_count;
+	if (expected_size > INT_MAX) {
+		print_error(String(op_name) + ": buffer count too large, would cause integer overflow.");
+		return;
+	}
 	if (len != expected_size) {
 		print_error(String(op_name) + ": buffer size " + itos(len) +
-				" does not match expected size " + itos(expected_size) +
+				" does not match expected size " + itos((int)expected_size) +
 				" (updateCount=" + itos(update_count) + ", deleteCount=" + itos(delete_count) + ")");
 		return;
 	}
@@ -1379,11 +1424,19 @@ void batch_update_visuals_impl(SpxSpriteMgr *mgr, const float *buffer_data, int 
 	}
 
 	int count = static_cast<int>(buffer_data[0]);
+	if (count < 0) {
+		print_error(String(op_name) + ": buffer count must be non-negative.");
+		return;
+	}
 
-	int expected_size = HEADER_SIZE + count * VISUAL_FIELDS_PER_SPRITE;
+	int64_t expected_size = (int64_t)HEADER_SIZE + (int64_t)count * VISUAL_FIELDS_PER_SPRITE;
+	if (expected_size > INT_MAX) {
+		print_error(String(op_name) + ": buffer count too large, would cause integer overflow.");
+		return;
+	}
 	if (len != expected_size) {
 		print_error(String(op_name) + ": buffer size " + itos(len) +
-				" does not match expected size " + itos(expected_size) +
+				" does not match expected size " + itos((int)expected_size) +
 				" (count=" + itos(count) + ")");
 		return;
 	}
@@ -1442,59 +1495,119 @@ void SpxSpriteMgr::batch_update_visuals(const float *buffer_data, int len) {
 	batch_update_visuals_impl(this, buffer_data, len, "batch_update_visuals");
 }
 
-GdArray SpxSpriteMgr::batch_retrieve_positions(GdArray objs) {
-	// Input: array of sprite IDs [id1, id2, id3, ...]
-	// Output: array of positions [x1, y1, x2, y2, x3, y3, ...]
-	if (!objs) {
-		return nullptr;
+void SpxSpriteMgr::_batch_write_positions(const GdObj *ids, int count, float *out, int out_len) {
+	if (count <= 0) {
+		return;
 	}
-
-	int count = objs->size;
-	if (count == 0) {
-		return nullptr;
-	}
-
-	// Check for integer overflow before multiplication (count * 2)
-	// Maximum safe value is INT_MAX / 2 to prevent overflow
 	if (count > INT_MAX / 2) {
-		print_error("batch_retrieve_positions: count too large, would cause integer overflow.");
-		return nullptr;
+		print_error("_batch_write_positions: count too large, would cause integer overflow.");
+		return;
 	}
 
-	// Create result array: 2 floats (x, y) per sprite
-	GdArray result = SpxBaseMgr::create_array(GD_ARRAY_TYPE_FLOAT, count * 2);
-	if (!result) {
-		return nullptr;
+	int need = count * 2;
+	if (!ids || !out || out_len < need) {
+		print_error("_batch_write_positions: invalid input or output buffer.");
+		return;
 	}
 
-	// Get pointer to input array (GdObj IDs) for faster access
-	const GdObj *obj_data = SpxBaseMgr::get_array<GdObj>(objs, 0);
-	float *result_data = SpxBaseMgr::get_array<float>(result, 0);
-
-	// Check for null pointers to prevent crashes with malformed arrays
-	if (count > 0 && (!obj_data || !result_data)) {
-		print_error("batch_retrieve_positions: Failed to access array data.");
-		SpxBaseMgr::free_array(result);
-		return nullptr;
-	}
-
-	// Process each sprite ID
-	int result_idx = 0;
+	int j = 0;
 	for (int i = 0; i < count; i++) {
-		GdObj sprite_id = obj_data[i];
-
-		SpxSprite *sprite = get_sprite(sprite_id);
+		GdObj id = ids[i];
+		SpxSprite *sprite = get_sprite(id);
 		if (sprite != nullptr) {
 			auto pos = sprite->get_position();
-			result_data[result_idx++] = pos.x;
-			result_data[result_idx++] = -pos.y;
+			out[j++] = pos.x;
+			out[j++] = -pos.y;
 		} else {
-			result_data[result_idx++] = 0.0f;
-			result_data[result_idx++] = 0.0f;
+			out[j++] = 0.0f;
+			out[j++] = 0.0f;
 		}
 	}
+}
 
-	return result;
+void SpxSpriteMgr::batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len) {
+	_batch_write_positions(ids, count, out, out_len);
+}
+
+void SpxSpriteMgr::batch_update_physics(const float *buffer_data, int len) {
+	// Buffer format: [count, cmd, spriteIdLowBits, spriteIdHighBits, a, b, reserved0, ...].
+	// Integer lanes are carried as raw float32 bits to preserve 32/64-bit ids and masks.
+	if (buffer_data == nullptr || len < 1) {
+		return;
+	}
+
+	int count = (int)buffer_data[0];
+	if (count <= 0) {
+		return;
+	}
+	int64_t required = 1 + (int64_t)count * SPX_PHYSICS_BATCH_FIELDS;
+	if (required > INT_MAX) {
+		print_error("batch_update_physics: count too large, would cause integer overflow.");
+		return;
+	}
+
+	if (len != required) {
+		print_error("batch_update_physics: buffer length is invalid.");
+		return;
+	}
+
+	int idx = 1;
+	for (int i = 0; i < count; i++) {
+		int cmd = (int)buffer_data[idx];
+		GdObj obj = read_gd_obj_lanes(&buffer_data[idx]);
+		SpxSprite *sprite = get_sprite(obj);
+		if (sprite != nullptr) {
+			float a = buffer_data[idx + 3];
+			float b = buffer_data[idx + 4];
+			switch (cmd) {
+				case SPX_PHYSICS_CMD_VELOCITY:
+					sprite->set_velocity(GdVec2(a, -b));
+					break;
+				case SPX_PHYSICS_CMD_GRAVITY:
+					sprite->set_gravity(a);
+					break;
+				case SPX_PHYSICS_CMD_MASS:
+					sprite->set_mass(a);
+					break;
+				case SPX_PHYSICS_CMD_MODE:
+					sprite->set_physics_mode((GdInt)(int32_t)read_u32_lane(a));
+					break;
+				case SPX_PHYSICS_CMD_USE_GRAVITY:
+					sprite->set_use_gravity(a != 0);
+					break;
+				case SPX_PHYSICS_CMD_GRAVITY_SCALE:
+					sprite->set_gravity_scale(a);
+					break;
+				case SPX_PHYSICS_CMD_DRAG:
+					sprite->set_drag(a);
+					break;
+				case SPX_PHYSICS_CMD_FRICTION:
+					sprite->set_friction(a);
+					break;
+				case SPX_PHYSICS_CMD_COLLISION_LAYER:
+					sprite->set_collision_layer((GdInt)read_u32_lane(a));
+					break;
+				case SPX_PHYSICS_CMD_COLLISION_MASK:
+					sprite->set_collision_mask((GdInt)read_u32_lane(a));
+					break;
+				case SPX_PHYSICS_CMD_TRIGGER_LAYER:
+					sprite->set_trigger_layer((GdInt)read_u32_lane(a));
+					break;
+				case SPX_PHYSICS_CMD_TRIGGER_MASK:
+					sprite->set_trigger_mask((GdInt)read_u32_lane(a));
+					break;
+				case SPX_PHYSICS_CMD_COLLISION_ENABLED:
+					sprite->set_collision_enabled(a != 0);
+					break;
+				case SPX_PHYSICS_CMD_TRIGGER_ENABLED:
+					sprite->set_trigger_enabled(a != 0);
+					break;
+				default:
+					break;
+			}
+		}
+		idx += SPX_PHYSICS_BATCH_FIELDS;
+	}
 }
 
 void SpxSpriteMgr::set_pixel_collision_sampling_step(GdInt step) {

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -53,6 +53,8 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
+#include <type_traits>
 
 #define DEFAULT_COLLISION_ALPHA_THRESHOLD 0.05
 
@@ -1316,13 +1318,21 @@ uint32_t read_u32_lane(float value) {
 	return bits;
 }
 
+template <typename T>
+T gd_obj_from_i64(int64_t value) {
+	if constexpr (std::is_pointer_v<T>) {
+		return reinterpret_cast<T>(static_cast<uintptr_t>(value));
+	}
+	return static_cast<T>(value);
+}
+
 GdObj read_gd_obj_lanes(const float *record) {
 	uint64_t low = read_u32_lane(record[1]);
 	uint64_t high = read_u32_lane(record[2]);
 	uint64_t bits = (high << 32) | low;
 	int64_t value = 0;
 	std::memcpy(&value, &bits, sizeof(value));
-	return static_cast<GdObj>(value);
+	return gd_obj_from_i64<GdObj>(value);
 }
 
 void batch_update_transforms_impl(SpxSpriteMgr *mgr, const float *buffer_data, int len, const char *op_name) {
@@ -1519,8 +1529,9 @@ void SpxSpriteMgr::_batch_write_positions(const GdObj *ids, int count, float *ou
 			out[j++] = pos.x;
 			out[j++] = -pos.y;
 		} else {
-			out[j++] = 0.0f;
-			out[j++] = 0.0f;
+			const float missing = std::numeric_limits<float>::quiet_NaN();
+			out[j++] = missing;
+			out[j++] = missing;
 		}
 	}
 }
@@ -1530,7 +1541,7 @@ void SpxSpriteMgr::batch_retrieve_positions(const GdObj *ids, int count, float *
 }
 
 void SpxSpriteMgr::batch_update_physics(const float *buffer_data, int len) {
-	// Buffer format: [count, cmd, spriteIdLowBits, spriteIdHighBits, a, b, reserved0, ...].
+	// Buffer format: [count] + count x [cmd, spriteIdLowBits, spriteIdHighBits, a, b, reserved0].
 	// Integer lanes are carried as raw float32 bits to preserve 32/64-bit ids and masks.
 	if (buffer_data == nullptr || len < 1) {
 		return;

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -119,6 +119,7 @@ private:
 	bool _erase_pixel_collision_pair(const TriggerPair &pair);
 	void _remove_collision_pairs_for_sprite(GdObj obj);
 	void _check_pixel_collision_events();
+	void _batch_write_positions(const GdObj *ids, int count, float *out, int out_len);
 
 public:
 	static StringName default_texture_anim;
@@ -297,7 +298,8 @@ public:
 	// batch sync
 	SPX_API void batch_update_transforms(const float *buffer_data, int len);
 	SPX_API void batch_update_visuals(const float *buffer_data, int len);
-	SPX_API GdArray batch_retrieve_positions(GdArray objs);
+	SPX_API void batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len);
+	SPX_API void batch_update_physics(const float *buffer_data, int len);
 };
 
 #endif // SPX_SPRITE_MGR_H

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -276,6 +276,30 @@ void gdspx_input_is_action_just_released(GdString *action, GdBool *ret_val) {
 	*ret_val = inputMgr->is_action_just_released(*action);
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_input_register_action(GdString *action, GdInt *ret_val) {
+	*ret_val = inputMgr->register_action(*action);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_input_get_axis_id(GdInt *neg_action_id, GdInt *pos_action_id, GdFloat *ret_val) {
+	*ret_val = inputMgr->get_axis_id(*neg_action_id, *pos_action_id);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_input_is_action_pressed_id(GdInt *action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_pressed_id(*action_id);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_input_is_action_just_pressed_id(GdInt *action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_just_pressed_id(*action_id);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_input_is_action_just_released_id(GdInt *action_id, GdBool *ret_val) {
+	*ret_val = inputMgr->is_action_just_released_id(*action_id);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_input_write_snapshot(float *out, int len) {
+	inputMgr->write_snapshot(out, len);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_navigation_setup_path_finder_with_size(GdVec2 *grid_size, GdVec2 *cell_size, GdBool *with_jump, GdBool *with_debug) {
 	 navigationMgr->setup_path_finder_with_size(*grid_size, *cell_size, *with_jump, *with_debug);
 }
@@ -1100,8 +1124,8 @@ void gdspx_sprite_batch_update_visuals(const float *buffer_data, int len) {
 	spriteMgr->batch_update_visuals(buffer_data, len);
 }
 EMSCRIPTEN_KEEPALIVE
-void gdspx_sprite_batch_retrieve_positions(GdArray *objs, GdArray *ret_val) {
-	*ret_val = spriteMgr->batch_retrieve_positions(*objs);
+void gdspx_sprite_batch_update_physics(const float *buffer_data, int len) {
+	spriteMgr->batch_update_physics(buffer_data, len);
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_tilemap_open_draw_tiles_with_size(GdInt *tile_size) {
@@ -1358,6 +1382,10 @@ void gdspx_ui_get_flip(GdObj *obj, GdBool *horizontal, GdBool *ret_val) {
 EMSCRIPTEN_KEEPALIVE
 void gdspx_ui_set_flip(GdObj *obj, GdBool *horizontal, GdBool *is_flip) {
 	 uiMgr->set_flip(*obj, *horizontal, *is_flip);
+}
+EMSCRIPTEN_KEEPALIVE
+void gdspx_sprite_batch_retrieve_positions(const GdObj *ids, int count, float *out, int out_len) {
+	spriteMgr->batch_retrieve_positions(ids, count, out, out_len);
 }
 
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -502,6 +502,64 @@ gdspx_input_is_action_just_released(action) {
 	FreeGdBool(_retValue); 
 	return _finalRetValue
 }
+gdspx_input_register_action(action) {
+	var _gdFuncPtr = Module._gdspx_input_register_action; 
+	var _retValue = AllocGdInt();
+	var _arg0 = ToGdString(action);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdString(_arg0); 
+	var _finalRetValue = this._readGdIntLike(_retValue, this._getGdIntScratch());
+	FreeGdInt(_retValue); 
+	return _finalRetValue
+}
+gdspx_input_get_axis_id(neg_action_id_low,neg_action_id_high,pos_action_id_low,pos_action_id_high) {
+	var _gdFuncPtr = Module._gdspx_input_get_axis_id; 
+	var _retValue = AllocGdFloat();
+	var _arg0 = Module._gdspx_new_int(neg_action_id_high, neg_action_id_low);
+	var _arg1 = Module._gdspx_new_int(pos_action_id_high, pos_action_id_low);
+	_gdFuncPtr(_arg0, _arg1, _retValue);
+	FreeGdInt(_arg0); 
+	FreeGdInt(_arg1); 
+	var _finalRetValue = ToJsFloat(_retValue);
+	FreeGdFloat(_retValue); 
+	return _finalRetValue
+}
+gdspx_input_is_action_pressed_id(action_id_low,action_id_high) {
+	var _gdFuncPtr = Module._gdspx_input_is_action_pressed_id; 
+	var _retValue = AllocGdBool();
+	var _arg0 = Module._gdspx_new_int(action_id_high, action_id_low);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdInt(_arg0); 
+	var _finalRetValue = ToJsBool(_retValue);
+	FreeGdBool(_retValue); 
+	return _finalRetValue
+}
+gdspx_input_is_action_just_pressed_id(action_id_low,action_id_high) {
+	var _gdFuncPtr = Module._gdspx_input_is_action_just_pressed_id; 
+	var _retValue = AllocGdBool();
+	var _arg0 = Module._gdspx_new_int(action_id_high, action_id_low);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdInt(_arg0); 
+	var _finalRetValue = ToJsBool(_retValue);
+	FreeGdBool(_retValue); 
+	return _finalRetValue
+}
+gdspx_input_is_action_just_released_id(action_id_low,action_id_high) {
+	var _gdFuncPtr = Module._gdspx_input_is_action_just_released_id; 
+	var _retValue = AllocGdBool();
+	var _arg0 = Module._gdspx_new_int(action_id_high, action_id_low);
+	_gdFuncPtr(_arg0, _retValue);
+	FreeGdInt(_arg0); 
+	var _finalRetValue = ToJsBool(_retValue);
+	FreeGdBool(_retValue); 
+	return _finalRetValue
+}
+gdspx_input_write_snapshot(out) {
+	var _gdFuncPtr = Module._gdspx_input_write_snapshot; 
+	var _arg0 = GetFastArrayWasmPtr(out);
+	var _arg1 = out.count;
+	_gdFuncPtr(_arg0, _arg1);
+}
 gdspx_navigation_setup_path_finder_with_size(grid_size,cell_size,with_jump,with_debug) {
 	var _gdFuncPtr = Module._gdspx_navigation_setup_path_finder_with_size; 
 	
@@ -2630,25 +2688,21 @@ gdspx_sprite_get_pixel_collision_sampling_step() {
 }
 gdspx_sprite_batch_update_transforms(buffer) {
 	var _gdFuncPtr = Module._gdspx_sprite_batch_update_transforms; 
-	var _arg0 = CopyFastArrayToWasm(buffer);
+	var _arg0 = GetFastArrayWasmPtr(buffer);
 	var _arg1 = buffer.count;
 	_gdFuncPtr(_arg0, _arg1);
 }
 gdspx_sprite_batch_update_visuals(buffer) {
 	var _gdFuncPtr = Module._gdspx_sprite_batch_update_visuals; 
-	var _arg0 = CopyFastArrayToWasm(buffer);
+	var _arg0 = GetFastArrayWasmPtr(buffer);
 	var _arg1 = buffer.count;
 	_gdFuncPtr(_arg0, _arg1);
 }
-gdspx_sprite_batch_retrieve_positions(objs) {
-	var _gdFuncPtr = Module._gdspx_sprite_batch_retrieve_positions; 
-	var _retValue = AllocGdArray();
-	var _arg0 = ToGdArray(objs);
-	_gdFuncPtr(_arg0, _retValue);
-	FreeGdArray(_arg0); 
-	var _finalRetValue = ToJsArray(_retValue);
-	FreeGdArray(_retValue); 
-	return _finalRetValue
+gdspx_sprite_batch_update_physics(buffer) {
+	var _gdFuncPtr = Module._gdspx_sprite_batch_update_physics; 
+	var _arg0 = GetFastArrayWasmPtr(buffer);
+	var _arg1 = buffer.count;
+	_gdFuncPtr(_arg0, _arg1);
 }
 gdspx_tilemap_open_draw_tiles_with_size(tile_size_low,tile_size_high) {
 	var _gdFuncPtr = Module._gdspx_tilemap_open_draw_tiles_with_size; 
@@ -3285,4 +3339,12 @@ gdspx_ui_set_flip(obj_low,obj_high,horizontal,is_flip) {
 	FreeGdBool(_arg1); 
 	FreeGdBool(_arg2); 
 
+}
+gdspx_sprite_batch_retrieve_positions(objs) {
+	var _gdFuncPtr = Module._gdspx_sprite_batch_retrieve_positions; 
+	var _fastRetValue = TryArrayTransformFastPath(_gdFuncPtr, objs, 6, 2, 2);
+	if (_fastRetValue == null) {
+		throw new Error("gdspx_sprite_batch_retrieve_positions fast path unavailable");
+	}
+	return _fastRetValue
 }}

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -556,7 +556,7 @@ gdspx_input_is_action_just_released_id(action_id_low,action_id_high) {
 }
 gdspx_input_write_snapshot(out) {
 	var _gdFuncPtr = Module._gdspx_input_write_snapshot; 
-	var _arg0 = GetFastArrayWasmPtr(out);
+	var _arg0 = RequireWasmFastArray(out, "gdspx_input_write_snapshot");
 	var _arg1 = out.count;
 	_gdFuncPtr(_arg0, _arg1);
 }

--- a/platform/web/js/engine/gdspx.util.js
+++ b/platform/web/js/engine/gdspx.util.js
@@ -2,6 +2,10 @@ const GDSPX_HAS_BIG_INT64 = typeof DataView.prototype.getBigInt64 === 'function'
 const GDSPX_UTF8_ENCODER = new TextEncoder();
 const GDSPX_UTF8_DECODER = new TextDecoder("utf-8");
 
+// -----------------------------------------------------------------------------
+// Wasm Function Pointers
+// -----------------------------------------------------------------------------
+
 let gdspxFunctionPointerModule = null;
 let gdspxMalloc = null;
 let gdspxFree = null;
@@ -44,50 +48,56 @@ let gdspxToGdArray = null;
 let gdspxToGdArrayRaw = null;
 let gdspxToJsArray = null;
 
+function BindGdspxFunctionPointers(module) {
+    ({
+        _cmalloc: gdspxMalloc,
+        _cfree: gdspxFree,
+        _gdspx_alloc_array: gdspxAllocArray,
+        _gdspx_alloc_bool: gdspxAllocBool,
+        _gdspx_alloc_color: gdspxAllocColor,
+        _gdspx_alloc_float: gdspxAllocFloat,
+        _gdspx_alloc_int: gdspxAllocInt,
+        _gdspx_alloc_obj: gdspxAllocObj,
+        _gdspx_alloc_rect2: gdspxAllocRect2,
+        _gdspx_alloc_string: gdspxAllocString,
+        _gdspx_alloc_vec2: gdspxAllocVec2,
+        _gdspx_alloc_vec3: gdspxAllocVec3,
+        _gdspx_alloc_vec4: gdspxAllocVec4,
+        _gdspx_free_array: gdspxFreeArray,
+        _gdspx_free_bool: gdspxFreeBool,
+        _gdspx_free_color: gdspxFreeColor,
+        _gdspx_free_cstr: gdspxFreeCstr,
+        _gdspx_free_float: gdspxFreeFloat,
+        _gdspx_free_int: gdspxFreeInt,
+        _gdspx_free_obj: gdspxFreeObj,
+        _gdspx_free_rect2: gdspxFreeRect2,
+        _gdspx_free_string: gdspxFreeString,
+        _gdspx_free_vec2: gdspxFreeVec2,
+        _gdspx_free_vec3: gdspxFreeVec3,
+        _gdspx_free_vec4: gdspxFreeVec4,
+        _gdspx_get_string: gdspxGetString,
+        _gdspx_get_string_len: gdspxGetStringLen,
+        _gdspx_new_bool: gdspxNewBool,
+        _gdspx_new_color: gdspxNewColor,
+        _gdspx_new_float: gdspxNewFloat,
+        _gdspx_new_int: gdspxNewInt,
+        _gdspx_new_obj: gdspxNewObj,
+        _gdspx_new_rect2: gdspxNewRect2,
+        _gdspx_new_string: gdspxNewString,
+        _gdspx_new_vec2: gdspxNewVec2,
+        _gdspx_new_vec3: gdspxNewVec3,
+        _gdspx_new_vec4: gdspxNewVec4,
+        _gdspx_to_gd_array: gdspxToGdArray,
+        _gdspx_to_gd_array_raw: gdspxToGdArrayRaw,
+        _gdspx_to_js_array: gdspxToJsArray,
+    } = module);
+}
+
 function EnsureGdspxFunctionPointers() {
     if (gdspxFunctionPointerModule === Module) {
         return;
     }
-    gdspxMalloc = Module._cmalloc;
-    gdspxFree = Module._cfree;
-    gdspxAllocArray = Module._gdspx_alloc_array;
-    gdspxAllocBool = Module._gdspx_alloc_bool;
-    gdspxAllocColor = Module._gdspx_alloc_color;
-    gdspxAllocFloat = Module._gdspx_alloc_float;
-    gdspxAllocInt = Module._gdspx_alloc_int;
-    gdspxAllocObj = Module._gdspx_alloc_obj;
-    gdspxAllocRect2 = Module._gdspx_alloc_rect2;
-    gdspxAllocString = Module._gdspx_alloc_string;
-    gdspxAllocVec2 = Module._gdspx_alloc_vec2;
-    gdspxAllocVec3 = Module._gdspx_alloc_vec3;
-    gdspxAllocVec4 = Module._gdspx_alloc_vec4;
-    gdspxFreeArray = Module._gdspx_free_array;
-    gdspxFreeBool = Module._gdspx_free_bool;
-    gdspxFreeColor = Module._gdspx_free_color;
-    gdspxFreeCstr = Module._gdspx_free_cstr;
-    gdspxFreeFloat = Module._gdspx_free_float;
-    gdspxFreeInt = Module._gdspx_free_int;
-    gdspxFreeObj = Module._gdspx_free_obj;
-    gdspxFreeRect2 = Module._gdspx_free_rect2;
-    gdspxFreeString = Module._gdspx_free_string;
-    gdspxFreeVec2 = Module._gdspx_free_vec2;
-    gdspxFreeVec3 = Module._gdspx_free_vec3;
-    gdspxFreeVec4 = Module._gdspx_free_vec4;
-    gdspxGetString = Module._gdspx_get_string;
-    gdspxGetStringLen = Module._gdspx_get_string_len;
-    gdspxNewBool = Module._gdspx_new_bool;
-    gdspxNewColor = Module._gdspx_new_color;
-    gdspxNewFloat = Module._gdspx_new_float;
-    gdspxNewInt = Module._gdspx_new_int;
-    gdspxNewObj = Module._gdspx_new_obj;
-    gdspxNewRect2 = Module._gdspx_new_rect2;
-    gdspxNewString = Module._gdspx_new_string;
-    gdspxNewVec2 = Module._gdspx_new_vec2;
-    gdspxNewVec3 = Module._gdspx_new_vec3;
-    gdspxNewVec4 = Module._gdspx_new_vec4;
-    gdspxToGdArray = Module._gdspx_to_gd_array;
-    gdspxToGdArrayRaw = Module._gdspx_to_gd_array_raw;
-    gdspxToJsArray = Module._gdspx_to_js_array;
+    BindGdspxFunctionPointers(Module);
     gdspxFunctionPointerModule = Module;
 }
 
@@ -103,7 +113,10 @@ function GetHeapDataView() {
     return gdspxHeapDataView;
 }
 
-// Bool-related functions
+// -----------------------------------------------------------------------------
+// Scalar and Object Value Bridges
+// -----------------------------------------------------------------------------
+
 function ToGdBool(value) {
     EnsureGdspxFunctionPointers();
     return gdspxNewBool(value);
@@ -129,6 +142,8 @@ function FreeGdBool(ptr) {
     gdspxFreeBool(ptr);
 }
 
+// Legacy Object aliases keep the Object/ObjectPtr naming used by some generated
+// bridge code while delegating to the canonical GdObj helpers below.
 function ToGdObject(object) {
     return ToGdObj(object);
 }
@@ -216,6 +231,10 @@ function FreeGdInt(ptr) {
     EnsureGdspxFunctionPointers();
     gdspxFreeInt(ptr);
 }
+
+// -----------------------------------------------------------------------------
+// Strings and Structured Math Types
+// -----------------------------------------------------------------------------
 
 function ToGdFloat(value) {
     EnsureGdspxFunctionPointers();
@@ -439,6 +458,10 @@ function FreeGdRect2(ptr) {
     gdspxFreeRect2(ptr);
 }
 
+// -----------------------------------------------------------------------------
+// Fast Arrays and Shared Wasm Transfer Buffers
+// -----------------------------------------------------------------------------
+
 const GDSPX_ARRAY_TYPE_INT64 = 1;
 const GDSPX_ARRAY_TYPE_FLOAT = 2;
 const GDSPX_ARRAY_TYPE_BYTE = 5;
@@ -447,15 +470,28 @@ const GDSPX_FAST_RING_BYTES = 1024 * 1024;
 const GDSPX_FAST_RING_ALIGN = 8;
 const GDSPX_FAST_POOL = "default";
 const GDSPX_INPUT_POOL = "input";
+const GDSPX_INPUT_SNAP_POOL = "input-snapshot";
 const GDSPX_RET_POOL = "return";
+const GDSPX_EMPTY_U8 = new Uint8Array(0);
 
 let fastRingModule = null;
 const fastRings = new Map();
-let inputActionModule = null;
-let inputActionEpoch = 0;
-const inputActionIds = new Map();
+const deferredFastRingFrees = [];
+const inputActionRegistry = {
+    module: null,
+    epoch: 0,
+    ids: new Map(),
+};
 let inputBridgeModule = null;
 let inputBridge = null;
+
+function HasActiveModule() {
+    return typeof Module !== 'undefined' && Module !== null;
+}
+
+function HasActiveModuleHeap() {
+    return HasActiveModule() && !!Module.HEAPU8;
+}
 
 function FreePtrMap(map) {
     for (const item of map.values()) {
@@ -485,6 +521,43 @@ function NextFastRingCap(minSize) {
     return capacity;
 }
 
+function GetFastArrayDataView(ptr, byteLength, module) {
+    if (!Number.isInteger(byteLength) || byteLength < 0) {
+        return GDSPX_EMPTY_U8;
+    }
+    if (!HasActiveModuleHeap() || module !== Module) {
+        return GDSPX_EMPTY_U8;
+    }
+    if (!Number.isInteger(ptr) || ptr < 0) {
+        return byteLength === 0 ? Module.HEAPU8.subarray(0, 0) : GDSPX_EMPTY_U8;
+    }
+    return Module.HEAPU8.subarray(ptr, ptr + byteLength);
+}
+
+function QueueDeferredFastRingFree(ptr, freeFn) {
+    if (!Number.isInteger(ptr) || ptr === 0 || typeof freeFn !== 'function') {
+        return;
+    }
+    deferredFastRingFrees.push({ ptr, free: freeFn });
+}
+
+function GdspxFlushDeferredFrees() {
+    if (deferredFastRingFrees.length === 0) {
+        return;
+    }
+    const pending = deferredFastRingFrees.splice(0, deferredFastRingFrees.length);
+    for (const item of pending) {
+        if (!item || item.ptr === 0 || typeof item.free !== 'function') {
+            continue;
+        }
+        try {
+            item.free(item.ptr);
+        } catch {
+            // The previous wasm instance may already be torn down during restart.
+        }
+    }
+}
+
 function GetFastRing(minSize, poolName = GDSPX_FAST_POOL) {
     EnsureGdspxFunctionPointers();
     if (typeof gdspxMalloc !== 'function' || typeof gdspxFree !== 'function') {
@@ -508,7 +581,7 @@ function GetFastRing(minSize, poolName = GDSPX_FAST_POOL) {
         return null;
     }
     if (ring && ring.ptr !== 0) {
-        ring.free(ring.ptr);
+        QueueDeferredFastRingFree(ring.ptr, ring.free);
     }
 
     ring = {
@@ -531,7 +604,7 @@ function GdspxBorrowFastArray(arrayType, count, dataSize, poolName = GDSPX_FAST_
     if (!Number.isInteger(count) || count < 0) {
         return null;
     }
-    if (typeof Module === 'undefined' || Module === null || !Module.HEAPU8) {
+    if (!HasActiveModuleHeap()) {
         return null;
     }
 
@@ -552,12 +625,11 @@ function GdspxBorrowFastArray(arrayType, count, dataSize, poolName = GDSPX_FAST_
     ring.offset += alignedSize;
     ring.sequence += 1;
 
-    return {
+    const wrapper = {
         __gdspx_fast_array: true,
         __gdspx_wasm_array: true,
         type: arrayType,
         count,
-        data: Module.HEAPU8.subarray(ptr, ptr + dataSize),
         ptr,
         module: Module,
         byteLength: dataSize,
@@ -565,6 +637,14 @@ function GdspxBorrowFastArray(arrayType, count, dataSize, poolName = GDSPX_FAST_
         pool: ring.pool,
         shared: typeof SharedArrayBuffer === 'function' && Module.HEAPU8.buffer instanceof SharedArrayBuffer,
     };
+    Object.defineProperty(wrapper, "data", {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return GetFastArrayDataView(this.ptr, this.byteLength, this.module);
+        },
+    });
+    return wrapper;
 }
 
 function FastArrayCount(array) {
@@ -576,6 +656,16 @@ function FastArrayByteLength(array) {
     const data = array && array.data;
     const length = Number(data && data.length);
     return Number.isInteger(length) && length >= 0 ? length : -1;
+}
+
+function IsFastArrayLike(array) {
+    if (!array || typeof array !== 'object') {
+        return false;
+    }
+    if (!Number.isInteger(array.type)) {
+        return false;
+    }
+    return FastArrayCount(array) >= 0 && FastArrayByteLength(array) >= 0;
 }
 
 function GetFastArrayElemSize(arrayType) {
@@ -633,8 +723,23 @@ function GetFastArrayWasmPtr(array) {
     return borrowed ? borrowed.ptr : 0;
 }
 
+function RequireWasmFastArray(array, opName) {
+    if (!array || array.__gdspx_wasm_array !== true) {
+        throw new Error(opName + " requires a pre-allocated Wasm array");
+    }
+    if (array.module !== Module) {
+        throw new Error(opName + " requires a Wasm array from the active module");
+    }
+    if (!Number.isInteger(array.ptr) || array.ptr < 0) {
+        throw new Error(opName + " requires a valid Wasm array pointer");
+    }
+    return array.ptr;
+}
+
+// Array-transform bridges take a fast-array input, run a raw wasm transform,
+// and return another fast-array view over the shared return pool.
 function TryArrayTransformFastPath(call, input, inputArrayType, outputArrayType, outputCountScale) {
-    if (!input || input.__gdspx_fast_array !== true) {
+    if (!IsFastArrayLike(input)) {
         return null;
     }
     if (!IsCompatibleFastArrayType(input.type, inputArrayType)) {
@@ -688,7 +793,7 @@ function TryArrayTransformFastPath(call, input, inputArrayType, outputArrayType,
 }
 
 function GdspxInputSnapshot() {
-    if (typeof Module === 'undefined' || Module === null) {
+    if (!HasActiveModule()) {
         return null;
     }
     const call = Module._gdspx_input_write_snapshot;
@@ -696,7 +801,7 @@ function GdspxInputSnapshot() {
         return null;
     }
 
-    const out = GdspxBorrowFastArray(GDSPX_ARRAY_TYPE_FLOAT, 3, 12, GDSPX_RET_POOL);
+    const out = GdspxBorrowFastArray(GDSPX_ARRAY_TYPE_FLOAT, 3, 12, GDSPX_INPUT_SNAP_POOL);
     if (!out || out.ptr === 0) {
         return null;
     }
@@ -704,8 +809,12 @@ function GdspxInputSnapshot() {
     return out;
 }
 
+// -----------------------------------------------------------------------------
+// Input Bridge and Action-ID Cache
+// -----------------------------------------------------------------------------
+
 function GetInputBridge() {
-    if (typeof Module === 'undefined' || Module === null) {
+    if (!HasActiveModule()) {
         return null;
     }
     if (typeof globalThis.gdspx_input_register_action === 'function') {
@@ -728,42 +837,63 @@ function ToStableActionID(value) {
     return Number(value) | 0;
 }
 
+// Input bridge wrappers expose simple JS calls while hiding whether the active
+// implementation comes from direct globals or a generated GdspxFuncs instance.
+function GetBoundBridgeCall(bridge, functionName) {
+    if (!bridge || typeof functionName !== 'string') {
+        return null;
+    }
+    const call = bridge[functionName];
+    return typeof call === 'function' ? call.bind(bridge) : null;
+}
+
+function GetInputActionBoolCallName(kind) {
+    switch (kind | 0) {
+        case 1:
+            return "gdspx_input_is_action_pressed_id";
+        case 2:
+            return "gdspx_input_is_action_just_pressed_id";
+        case 3:
+            return "gdspx_input_is_action_just_released_id";
+        default:
+            return null;
+    }
+}
+
 function EnsureInputActionRegistry() {
-    if (typeof Module === 'undefined' || Module === null) {
+    if (!HasActiveModule()) {
         return false;
     }
-    if (inputActionModule !== Module) {
-        inputActionModule = Module;
-        inputActionEpoch += 1;
-        inputActionIds.clear();
+    if (inputActionRegistry.module !== Module) {
+        inputActionRegistry.module = Module;
+        inputActionRegistry.epoch += 1;
+        inputActionRegistry.ids.clear();
     }
     return true;
 }
 
 function GdspxInputActionEpoch() {
     EnsureInputActionRegistry();
-    return inputActionEpoch;
+    return inputActionRegistry.epoch;
 }
 
 function GdspxInputActionID(action) {
     if (!EnsureInputActionRegistry()) {
         return -1;
     }
-    if (inputActionIds.has(action)) {
-        return inputActionIds.get(action);
+    if (inputActionRegistry.ids.has(action)) {
+        return inputActionRegistry.ids.get(action);
     }
 
     const bridge = GetInputBridge();
-    const call = bridge && typeof bridge.gdspx_input_register_action === 'function'
-        ? bridge.gdspx_input_register_action.bind(bridge)
-        : null;
+    const call = GetBoundBridgeCall(bridge, "gdspx_input_register_action");
     if (typeof call !== 'function') {
         return -1;
     }
 
     const id = ToStableActionID(call(action));
     if (id >= 0) {
-        inputActionIds.set(action, id);
+        inputActionRegistry.ids.set(action, id);
     }
     return id;
 }
@@ -774,26 +904,11 @@ function GdspxInputActionBool(kind, actionID) {
     }
 
     const bridge = GetInputBridge();
-    let call = null;
-    switch (kind | 0) {
-        case 1:
-            call = bridge && typeof bridge.gdspx_input_is_action_pressed_id === 'function'
-                ? bridge.gdspx_input_is_action_pressed_id.bind(bridge)
-                : null;
-            break;
-        case 2:
-            call = bridge && typeof bridge.gdspx_input_is_action_just_pressed_id === 'function'
-                ? bridge.gdspx_input_is_action_just_pressed_id.bind(bridge)
-                : null;
-            break;
-        case 3:
-            call = bridge && typeof bridge.gdspx_input_is_action_just_released_id === 'function'
-                ? bridge.gdspx_input_is_action_just_released_id.bind(bridge)
-                : null;
-            break;
-        default:
-            return null;
+    const callName = GetInputActionBoolCallName(kind);
+    if (callName == null) {
+        return null;
     }
+    const call = GetBoundBridgeCall(bridge, callName);
     if (typeof call !== 'function') {
         return null;
     }
@@ -805,14 +920,16 @@ function GdspxInputAxisByID(negActionID, posActionID) {
         return null;
     }
     const bridge = GetInputBridge();
-    const call = bridge && typeof bridge.gdspx_input_get_axis_id === 'function'
-        ? bridge.gdspx_input_get_axis_id.bind(bridge)
-        : null;
+    const call = GetBoundBridgeCall(bridge, "gdspx_input_get_axis_id");
     if (typeof call !== 'function') {
         return null;
     }
     return Number(call(negActionID | 0, 0, posActionID | 0, 0));
 }
+
+// -----------------------------------------------------------------------------
+// Batch Helpers and Generic Array Serialization
+// -----------------------------------------------------------------------------
 
 function GdspxBatchSpritePhysics(buffer) {
     if (!buffer || buffer.__gdspx_fast_array !== true) {
@@ -825,7 +942,7 @@ function GdspxBatchSpritePhysics(buffer) {
     if (count <= 0 || FastArrayByteLength(buffer) < count * 4) {
         return false;
     }
-    if (typeof Module === 'undefined' || Module === null) {
+    if (!HasActiveModule()) {
         return false;
     }
     const call = Module._gdspx_sprite_batch_update_physics;

--- a/platform/web/js/engine/gdspx.util.js
+++ b/platform/web/js/engine/gdspx.util.js
@@ -439,33 +439,405 @@ function FreeGdRect2(ptr) {
     gdspxFreeRect2(ptr);
 }
 
-const gdArrayScratchByType = new Map();
+const GDSPX_ARRAY_TYPE_INT64 = 1;
+const GDSPX_ARRAY_TYPE_FLOAT = 2;
+const GDSPX_ARRAY_TYPE_BYTE = 5;
+const GDSPX_ARRAY_TYPE_GDOBJ = 6;
+const GDSPX_FAST_RING_BYTES = 1024 * 1024;
+const GDSPX_FAST_RING_ALIGN = 8;
+const GDSPX_FAST_POOL = "default";
+const GDSPX_INPUT_POOL = "input";
+const GDSPX_RET_POOL = "return";
 
-function getGdArrayScratch(arrayType, minSize) {
-    EnsureGdspxFunctionPointers();
-    let scratch = gdArrayScratchByType.get(arrayType);
-    if (!scratch) {
-        scratch = { ptr: 0, capacity: 0 };
-        gdArrayScratchByType.set(arrayType, scratch);
-    }
-    if (minSize > scratch.capacity) {
-        if (scratch.ptr !== 0) {
-            gdspxFree(scratch.ptr);
+let fastRingModule = null;
+const fastRings = new Map();
+let inputActionModule = null;
+let inputActionEpoch = 0;
+const inputActionIds = new Map();
+let inputBridgeModule = null;
+let inputBridge = null;
+
+function FreePtrMap(map) {
+    for (const item of map.values()) {
+        if (item.ptr !== 0 && typeof item.free === 'function') {
+            try {
+                item.free(item.ptr);
+            } catch {
+                // The previous wasm instance may already be torn down during restart.
+            }
         }
-        scratch.ptr = minSize > 0 ? gdspxMalloc(minSize) : 0;
-        scratch.capacity = minSize;
     }
-    return scratch;
+    map.clear();
 }
 
-function CopyFastArrayToWasm(array) {
+function AlignFastSize(size) {
+    if (size <= 0) {
+        return 0;
+    }
+    return Math.ceil(size / GDSPX_FAST_RING_ALIGN) * GDSPX_FAST_RING_ALIGN;
+}
+
+function NextFastRingCap(minSize) {
+    let capacity = GDSPX_FAST_RING_BYTES;
+    while (capacity < minSize) {
+        capacity *= 2;
+    }
+    return capacity;
+}
+
+function GetFastRing(minSize, poolName = GDSPX_FAST_POOL) {
+    EnsureGdspxFunctionPointers();
+    if (typeof gdspxMalloc !== 'function' || typeof gdspxFree !== 'function') {
+        return null;
+    }
+    if (fastRingModule !== Module) {
+        FreePtrMap(fastRings);
+        fastRingModule = Module;
+    }
+
+    const pool = String(poolName || GDSPX_FAST_POOL);
+    let ring = fastRings.get(pool);
+    const required = AlignFastSize(minSize);
+    if (ring && required <= ring.capacity) {
+        return ring;
+    }
+
+    const capacity = NextFastRingCap(required);
+    const ptr = gdspxMalloc(capacity);
+    if (ptr === 0) {
+        return null;
+    }
+    if (ring && ring.ptr !== 0) {
+        ring.free(ring.ptr);
+    }
+
+    ring = {
+        ptr,
+        capacity,
+        offset: 0,
+        sequence: 0,
+        module: Module,
+        free: gdspxFree,
+        pool,
+    };
+    fastRings.set(pool, ring);
+    return ring;
+}
+
+function GdspxBorrowFastArray(arrayType, count, dataSize, poolName = GDSPX_FAST_POOL) {
+    if (!Number.isInteger(dataSize) || dataSize < 0) {
+        return null;
+    }
+    if (!Number.isInteger(count) || count < 0) {
+        return null;
+    }
+    if (typeof Module === 'undefined' || Module === null || !Module.HEAPU8) {
+        return null;
+    }
+
+    const ring = GetFastRing(dataSize, poolName);
+    if (!ring || ring.ptr === 0) {
+        return null;
+    }
+
+    const alignedSize = AlignFastSize(dataSize);
+    if (alignedSize > ring.capacity) {
+        return null;
+    }
+    if (ring.offset + alignedSize > ring.capacity) {
+        ring.offset = 0;
+    }
+
+    const ptr = ring.ptr + ring.offset;
+    ring.offset += alignedSize;
+    ring.sequence += 1;
+
+    return {
+        __gdspx_fast_array: true,
+        __gdspx_wasm_array: true,
+        type: arrayType,
+        count,
+        data: Module.HEAPU8.subarray(ptr, ptr + dataSize),
+        ptr,
+        module: Module,
+        byteLength: dataSize,
+        sequence: ring.sequence,
+        pool: ring.pool,
+        shared: typeof SharedArrayBuffer === 'function' && Module.HEAPU8.buffer instanceof SharedArrayBuffer,
+    };
+}
+
+function FastArrayCount(array) {
+    const count = Number(array && array.count);
+    return Number.isInteger(count) && count >= 0 ? count : -1;
+}
+
+function FastArrayByteLength(array) {
+    const data = array && array.data;
+    const length = Number(data && data.length);
+    return Number.isInteger(length) && length >= 0 ? length : -1;
+}
+
+function GetFastArrayElemSize(arrayType) {
+    switch (arrayType) {
+    case GDSPX_ARRAY_TYPE_INT64:
+    case GDSPX_ARRAY_TYPE_GDOBJ:
+        return 8;
+    case GDSPX_ARRAY_TYPE_FLOAT:
+        return 4;
+    case GDSPX_ARRAY_TYPE_BYTE:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+function IsCompatibleFastArrayType(actualType, expectedType) {
+    if (actualType === expectedType) {
+        return true;
+    }
+    return expectedType === GDSPX_ARRAY_TYPE_GDOBJ && actualType === GDSPX_ARRAY_TYPE_INT64;
+}
+
+function BorrowCopiedFastArray(array, poolName = GDSPX_INPUT_POOL) {
     const data = array.data;
     const dataSize = data.length;
-    const scratch = getGdArrayScratch(array.type, dataSize);
-    if (dataSize > 0) {
-        Module.HEAPU8.set(data, scratch.ptr);
+    const count = FastArrayCount(array);
+    if (count < 0) {
+        return null;
     }
-    return scratch.ptr;
+    // Keep transient input copies separate from return buffers so fast-path
+    // calls do not trample results that are still being read by Go.
+    const borrowed = GdspxBorrowFastArray(array.type, count, dataSize, poolName);
+    if (dataSize > 0 && (!borrowed || borrowed.ptr === 0)) {
+        throw new Error("Failed to allocate fast GdArray input buffer");
+    }
+    if (dataSize > 0) {
+        Module.HEAPU8.set(data, borrowed.ptr);
+    }
+    return borrowed;
+}
+
+function GetFastArrayWasmPtr(array) {
+    if (array.__gdspx_wasm_array === true) {
+        if (array.module !== Module) {
+            return 0;
+        }
+        if (!Number.isInteger(array.ptr) || array.ptr < 0) {
+            return 0;
+        }
+        return array.ptr;
+    }
+
+    const borrowed = BorrowCopiedFastArray(array);
+    return borrowed ? borrowed.ptr : 0;
+}
+
+function TryArrayTransformFastPath(call, input, inputArrayType, outputArrayType, outputCountScale) {
+    if (!input || input.__gdspx_fast_array !== true) {
+        return null;
+    }
+    if (!IsCompatibleFastArrayType(input.type, inputArrayType)) {
+        return null;
+    }
+
+    const count = FastArrayCount(input);
+    if (count < 0 || count > 0x3fffffff) {
+        return null;
+    }
+    const inputElemSize = GetFastArrayElemSize(inputArrayType);
+    if (inputElemSize === 0 || FastArrayByteLength(input) < count * inputElemSize) {
+        return null;
+    }
+
+    if (typeof call !== 'function') {
+        return null;
+    }
+    if (!Number.isInteger(outputCountScale) || outputCountScale < 0) {
+        return null;
+    }
+    if (count > 0 && outputCountScale > Math.floor(0x7fffffff / count)) {
+        return null;
+    }
+
+    const inputPtr = GetFastArrayWasmPtr(input);
+    if (count > 0 && inputPtr === 0) {
+        return null;
+    }
+
+    const outCount = count * outputCountScale;
+    const outputElemSize = GetFastArrayElemSize(outputArrayType);
+    if (outputElemSize === 0 || outCount > Math.floor(0x7fffffff / outputElemSize)) {
+        return null;
+    }
+    const outBytes = outCount * outputElemSize;
+    const out = GdspxBorrowFastArray(
+        outputArrayType,
+        outCount,
+        outBytes,
+        GDSPX_RET_POOL,
+    );
+    if (!out || out.ptr === 0) {
+        return null;
+    }
+
+    if (count > 0) {
+        call(inputPtr, count, out.ptr, outCount);
+    }
+    return out;
+}
+
+function GdspxInputSnapshot() {
+    if (typeof Module === 'undefined' || Module === null) {
+        return null;
+    }
+    const call = Module._gdspx_input_write_snapshot;
+    if (typeof call !== 'function') {
+        return null;
+    }
+
+    const out = GdspxBorrowFastArray(GDSPX_ARRAY_TYPE_FLOAT, 3, 12, GDSPX_RET_POOL);
+    if (!out || out.ptr === 0) {
+        return null;
+    }
+    call(out.ptr, out.count);
+    return out;
+}
+
+function GetInputBridge() {
+    if (typeof Module === 'undefined' || Module === null) {
+        return null;
+    }
+    if (typeof globalThis.gdspx_input_register_action === 'function') {
+        return globalThis;
+    }
+    if (inputBridgeModule !== Module) {
+        inputBridgeModule = Module;
+        inputBridge = typeof GdspxFuncs === 'function' ? new GdspxFuncs() : null;
+    }
+    return inputBridge;
+}
+
+function ToStableActionID(value) {
+    if (value && typeof value.low === 'number') {
+        return value.low | 0;
+    }
+    if (typeof value === 'bigint') {
+        return Number(BigInt.asIntN(32, value));
+    }
+    return Number(value) | 0;
+}
+
+function EnsureInputActionRegistry() {
+    if (typeof Module === 'undefined' || Module === null) {
+        return false;
+    }
+    if (inputActionModule !== Module) {
+        inputActionModule = Module;
+        inputActionEpoch += 1;
+        inputActionIds.clear();
+    }
+    return true;
+}
+
+function GdspxInputActionEpoch() {
+    EnsureInputActionRegistry();
+    return inputActionEpoch;
+}
+
+function GdspxInputActionID(action) {
+    if (!EnsureInputActionRegistry()) {
+        return -1;
+    }
+    if (inputActionIds.has(action)) {
+        return inputActionIds.get(action);
+    }
+
+    const bridge = GetInputBridge();
+    const call = bridge && typeof bridge.gdspx_input_register_action === 'function'
+        ? bridge.gdspx_input_register_action.bind(bridge)
+        : null;
+    if (typeof call !== 'function') {
+        return -1;
+    }
+
+    const id = ToStableActionID(call(action));
+    if (id >= 0) {
+        inputActionIds.set(action, id);
+    }
+    return id;
+}
+
+function GdspxInputActionBool(kind, actionID) {
+    if (!EnsureInputActionRegistry()) {
+        return null;
+    }
+
+    const bridge = GetInputBridge();
+    let call = null;
+    switch (kind | 0) {
+        case 1:
+            call = bridge && typeof bridge.gdspx_input_is_action_pressed_id === 'function'
+                ? bridge.gdspx_input_is_action_pressed_id.bind(bridge)
+                : null;
+            break;
+        case 2:
+            call = bridge && typeof bridge.gdspx_input_is_action_just_pressed_id === 'function'
+                ? bridge.gdspx_input_is_action_just_pressed_id.bind(bridge)
+                : null;
+            break;
+        case 3:
+            call = bridge && typeof bridge.gdspx_input_is_action_just_released_id === 'function'
+                ? bridge.gdspx_input_is_action_just_released_id.bind(bridge)
+                : null;
+            break;
+        default:
+            return null;
+    }
+    if (typeof call !== 'function') {
+        return null;
+    }
+    return !!call(actionID | 0, 0);
+}
+
+function GdspxInputAxisByID(negActionID, posActionID) {
+    if (!EnsureInputActionRegistry()) {
+        return null;
+    }
+    const bridge = GetInputBridge();
+    const call = bridge && typeof bridge.gdspx_input_get_axis_id === 'function'
+        ? bridge.gdspx_input_get_axis_id.bind(bridge)
+        : null;
+    if (typeof call !== 'function') {
+        return null;
+    }
+    return Number(call(negActionID | 0, 0, posActionID | 0, 0));
+}
+
+function GdspxBatchSpritePhysics(buffer) {
+    if (!buffer || buffer.__gdspx_fast_array !== true) {
+        return false;
+    }
+    if (buffer.type !== GDSPX_ARRAY_TYPE_FLOAT) {
+        return false;
+    }
+    const count = FastArrayCount(buffer);
+    if (count <= 0 || FastArrayByteLength(buffer) < count * 4) {
+        return false;
+    }
+    if (typeof Module === 'undefined' || Module === null) {
+        return false;
+    }
+    const call = Module._gdspx_sprite_batch_update_physics;
+    if (typeof call !== 'function') {
+        return false;
+    }
+    const ptr = GetFastArrayWasmPtr(buffer);
+    if (ptr === 0) {
+        return false;
+    }
+    call(ptr, count);
+    return true;
 }
 
 function ToGdArray(array) {
@@ -474,7 +846,10 @@ function ToGdArray(array) {
         throw new Error('Invalid array structure. Expected {type, count, data}');
     }
     if (array.__gdspx_fast_array === true) {
-        const dataPtr = CopyFastArrayToWasm(array);
+        const dataPtr = GetFastArrayWasmPtr(array);
+        if (array.data.length > 0 && dataPtr === 0) {
+            throw new Error("Failed to access fast GdArray data");
+        }
         return gdspxToGdArrayRaw(dataPtr, array.data.length, array.count, array.type);
     }
     const dataSize = array.length;

--- a/platform/web/js/libs/library_godot_gdspx.js
+++ b/platform/web/js/libs/library_godot_gdspx.js
@@ -1,28 +1,31 @@
-const DIRECT_CALLBACK_HANDLER_SLOTS = globalThis.__spxDirectCallbackHandlerSlots || (globalThis.__spxDirectCallbackHandlerSlots = Object.create(null));
-const CONTACT_CALLBACK_EXPORT_NAMES = [
-	"gdspx_on_collision_enter",
-	"gdspx_on_collision_stay",
-	"gdspx_on_collision_exit",
-	"gdspx_on_trigger_enter",
-	"gdspx_on_trigger_stay",
-	"gdspx_on_trigger_exit",
-];
-const CONTACT_CALLBACK_EVENT_NAMES = [
-	"OnCollisionEnter",
-	"OnCollisionStay",
-	"OnCollisionExit",
-	"OnTriggerEnter",
-	"OnTriggerStay",
-	"OnTriggerExit",
-];
-const CONTACT_EVENT_FIELDS = 5;
-const CONTACT_EVENT_WARN_THRESHOLD = 4096 * CONTACT_EVENT_FIELDS;
-
 const GodotGdspx = {
 	$GodotGdspx__deps: ['$GodotConfig', '$GodotRuntime', '$GodotFS'],
 	$GodotGdspx: {
+		// Keep library-local constants under $GodotGdspx itself because emscripten
+		// library methods are emitted independently and should not rely on top-level
+		// lexical bindings remaining in scope at runtime.
+		directCallbackHandlerSlots: globalThis.__spxDirectCallbackHandlerSlots || (globalThis.__spxDirectCallbackHandlerSlots = Object.create(null)),
+		contactCallbackExportNames: [
+			"gdspx_on_collision_enter",
+			"gdspx_on_collision_stay",
+			"gdspx_on_collision_exit",
+			"gdspx_on_trigger_enter",
+			"gdspx_on_trigger_stay",
+			"gdspx_on_trigger_exit",
+		],
+		contactCallbackEventNames: [
+			"OnCollisionEnter",
+			"OnCollisionStay",
+			"OnCollisionExit",
+			"OnTriggerEnter",
+			"OnTriggerStay",
+			"OnTriggerExit",
+		],
+		contactEventFields: 5,
+		contactEventWarnThreshold: 4096 * 5,
+
 		getDirectHandler: function (exportName) {
-			const directHandler = DIRECT_CALLBACK_HANDLER_SLOTS[exportName];
+			const directHandler = GodotGdspx.directCallbackHandlerSlots[exportName];
 			return typeof directHandler === 'function' ? directHandler : null;
 		},
 
@@ -103,7 +106,7 @@ const GodotGdspx = {
 			const other = GodotGdspx.toContactLowHigh(otherPtr);
 			const events = GodotGdspx.contactEvents;
 			events.push(type, self.low, self.high, other.low, other.high);
-			if (!GodotGdspx.contactEventsWarned && events.length >= CONTACT_EVENT_WARN_THRESHOLD) {
+			if (!GodotGdspx.contactEventsWarned && events.length >= GodotGdspx.contactEventWarnThreshold) {
 				GodotGdspx.contactEventsWarned = true;
 				GodotRuntime.error("gdspx contact event queue is growing large before flush.");
 			}
@@ -127,8 +130,8 @@ const GodotGdspx = {
 				const type = events[i] | 0;
 				const self = { low: events[i + 1] >>> 0, high: events[i + 2] >>> 0 };
 				const other = { low: events[i + 3] >>> 0, high: events[i + 4] >>> 0 };
-				const exportName = CONTACT_CALLBACK_EXPORT_NAMES[type - 1];
-				const eventName = CONTACT_CALLBACK_EVENT_NAMES[type - 1];
+				const exportName = GodotGdspx.contactCallbackExportNames[type - 1];
+				const eventName = GodotGdspx.contactCallbackEventNames[type - 1];
 				if (exportName && eventName) {
 					const directHandler = GodotGdspx.getDirectHandler(exportName);
 					GodotGdspx.call2(exportName, eventName, self, other, directHandler);

--- a/platform/web/js/libs/library_godot_gdspx.js
+++ b/platform/web/js/libs/library_godot_gdspx.js
@@ -1,4 +1,20 @@
 const DIRECT_CALLBACK_HANDLER_SLOTS = globalThis.__spxDirectCallbackHandlerSlots || (globalThis.__spxDirectCallbackHandlerSlots = Object.create(null));
+const CONTACT_CALLBACK_EXPORT_NAMES = [
+	"gdspx_on_collision_enter",
+	"gdspx_on_collision_stay",
+	"gdspx_on_collision_exit",
+	"gdspx_on_trigger_enter",
+	"gdspx_on_trigger_stay",
+	"gdspx_on_trigger_exit",
+];
+const CONTACT_CALLBACK_EVENT_NAMES = [
+	"OnCollisionEnter",
+	"OnCollisionStay",
+	"OnCollisionExit",
+	"OnTriggerEnter",
+	"OnTriggerStay",
+	"OnTriggerExit",
+];
 
 const GodotGdspx = {
 	$GodotGdspx__deps: ['$GodotConfig', '$GodotRuntime', '$GodotFS'],
@@ -58,6 +74,40 @@ const GodotGdspx = {
 		call2: function (exportName, eventName, arg0, arg1, directHandler = null) {
 			GodotGdspx.callN(exportName, eventName, directHandler, arg0, arg1);
 		},
+
+		contactEvents: [],
+
+		queueContact: function (type, selfPtr, otherPtr) {
+			const self = GodotRuntime.ToJsInt(selfPtr);
+			const other = GodotRuntime.ToJsInt(otherPtr);
+			GodotGdspx.contactEvents.push(type, self.low, self.high, other.low, other.high);
+		},
+
+		flushContactEvents: function () {
+			const events = GodotGdspx.contactEvents;
+			if (events.length === 0) {
+				return;
+			}
+			GodotGdspx.contactEvents = [];
+
+			const direct = typeof globalThis.gdspx_on_contact_events === 'function' ? globalThis.gdspx_on_contact_events : null;
+			if (direct) {
+				direct(events);
+				return;
+			}
+
+			for (let i = 0; i + 4 < events.length; i += 5) {
+				const type = events[i] | 0;
+				const self = { low: events[i + 1] >>> 0, high: events[i + 2] >>> 0 };
+				const other = { low: events[i + 3] >>> 0, high: events[i + 4] >>> 0 };
+				const exportName = CONTACT_CALLBACK_EXPORT_NAMES[type - 1];
+				const eventName = CONTACT_CALLBACK_EVENT_NAMES[type - 1];
+				if (exportName && eventName) {
+					const directHandler = GodotGdspx.getDirectHandler(exportName);
+					GodotGdspx.call2(exportName, eventName, self, other, directHandler);
+				}
+			}
+		},
 	},
 
 	// godot gdspx extensions
@@ -73,12 +123,14 @@ const GodotGdspx = {
 
 	godot_js_spx_on_engine_update__sig: 'vf',
 	godot_js_spx_on_engine_update: function (delta) {
+		GodotGdspx.flushContactEvents();
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_update");
 		GodotGdspx.call1("gdspx_on_engine_update", "OnEngineUpdate", delta, directHandler);
 	},
 
 	godot_js_spx_on_engine_fixed_update__sig: 'vf',
 	godot_js_spx_on_engine_fixed_update: function (delta) {
+		GodotGdspx.flushContactEvents();
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_fixed_update");
 		GodotGdspx.call1("gdspx_on_engine_fixed_update", "OnEngineFixedUpdate", delta, directHandler);
 	},
@@ -247,38 +299,32 @@ const GodotGdspx = {
 
 	godot_js_spx_on_collision_enter__sig: 'vii',
 	godot_js_spx_on_collision_enter: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_collision_enter");
-		GodotGdspx.call2("gdspx_on_collision_enter", "OnCollisionEnter", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(1, self_id, other_id);
 	},
 
 	godot_js_spx_on_collision_stay__sig: 'vii',
 	godot_js_spx_on_collision_stay: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_collision_stay");
-		GodotGdspx.call2("gdspx_on_collision_stay", "OnCollisionStay", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(2, self_id, other_id);
 	},
 
 	godot_js_spx_on_collision_exit__sig: 'vii',
 	godot_js_spx_on_collision_exit: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_collision_exit");
-		GodotGdspx.call2("gdspx_on_collision_exit", "OnCollisionExit", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(3, self_id, other_id);
 	},
 
 	godot_js_spx_on_trigger_enter__sig: 'vii',
 	godot_js_spx_on_trigger_enter: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_trigger_enter");
-		GodotGdspx.call2("gdspx_on_trigger_enter", "OnTriggerEnter", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(4, self_id, other_id);
 	},
 
 	godot_js_spx_on_trigger_stay__sig: 'vii',
 	godot_js_spx_on_trigger_stay: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_trigger_stay");
-		GodotGdspx.call2("gdspx_on_trigger_stay", "OnTriggerStay", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(5, self_id, other_id);
 	},
 
 	godot_js_spx_on_trigger_exit__sig: 'vii',
 	godot_js_spx_on_trigger_exit: function (self_id, other_id) {
-		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_trigger_exit");
-		GodotGdspx.call2("gdspx_on_trigger_exit", "OnTriggerExit", GodotGdspx.toCallbackInt(self_id, directHandler), GodotGdspx.toCallbackInt(other_id, directHandler), directHandler);
+		GodotGdspx.queueContact(6, self_id, other_id);
 	},
 
 	godot_js_spx_on_ui_ready__sig: 'vi',

--- a/platform/web/js/libs/library_godot_gdspx.js
+++ b/platform/web/js/libs/library_godot_gdspx.js
@@ -15,6 +15,8 @@ const CONTACT_CALLBACK_EVENT_NAMES = [
 	"OnTriggerStay",
 	"OnTriggerExit",
 ];
+const CONTACT_EVENT_FIELDS = 5;
+const CONTACT_EVENT_WARN_THRESHOLD = 4096 * CONTACT_EVENT_FIELDS;
 
 const GodotGdspx = {
 	$GodotGdspx__deps: ['$GodotConfig', '$GodotRuntime', '$GodotFS'],
@@ -75,12 +77,36 @@ const GodotGdspx = {
 			GodotGdspx.callN(exportName, eventName, directHandler, arg0, arg1);
 		},
 
+		toContactLowHigh: function (ptr) {
+			const value = GodotRuntime.ToJsInt(ptr);
+			if (value && typeof value === 'object' && typeof value.low === 'number' && typeof value.high === 'number') {
+				return value;
+			}
+			if (typeof value === 'bigint') {
+				return {
+					low: Number(value & 0xffffffffn) >>> 0,
+					high: Number((value >> 32n) & 0xffffffffn) >>> 0,
+				};
+			}
+			const numberValue = Number(value) || 0;
+			return {
+				low: numberValue >>> 0,
+				high: (numberValue / 0x100000000) >>> 0,
+			};
+		},
+
 		contactEvents: [],
+		contactEventsWarned: false,
 
 		queueContact: function (type, selfPtr, otherPtr) {
-			const self = GodotRuntime.ToJsInt(selfPtr);
-			const other = GodotRuntime.ToJsInt(otherPtr);
-			GodotGdspx.contactEvents.push(type, self.low, self.high, other.low, other.high);
+			const self = GodotGdspx.toContactLowHigh(selfPtr);
+			const other = GodotGdspx.toContactLowHigh(otherPtr);
+			const events = GodotGdspx.contactEvents;
+			events.push(type, self.low, self.high, other.low, other.high);
+			if (!GodotGdspx.contactEventsWarned && events.length >= CONTACT_EVENT_WARN_THRESHOLD) {
+				GodotGdspx.contactEventsWarned = true;
+				GodotRuntime.error("gdspx contact event queue is growing large before flush.");
+			}
 		},
 
 		flushContactEvents: function () {
@@ -89,10 +115,11 @@ const GodotGdspx = {
 				return;
 			}
 			GodotGdspx.contactEvents = [];
+			GodotGdspx.contactEventsWarned = false;
 
 			const direct = typeof globalThis.gdspx_on_contact_events === 'function' ? globalThis.gdspx_on_contact_events : null;
 			if (direct) {
-				direct(events);
+				direct(new Uint8Array(Uint32Array.from(events).buffer));
 				return;
 			}
 
@@ -123,6 +150,9 @@ const GodotGdspx = {
 
 	godot_js_spx_on_engine_update__sig: 'vf',
 	godot_js_spx_on_engine_update: function (delta) {
+		if (typeof GdspxFlushDeferredFrees === 'function') {
+			GdspxFlushDeferredFrees();
+		}
 		GodotGdspx.flushContactEvents();
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_update");
 		GodotGdspx.call1("gdspx_on_engine_update", "OnEngineUpdate", delta, directHandler);
@@ -130,6 +160,9 @@ const GodotGdspx = {
 
 	godot_js_spx_on_engine_fixed_update__sig: 'vf',
 	godot_js_spx_on_engine_fixed_update: function (delta) {
+		if (typeof GdspxFlushDeferredFrees === 'function') {
+			GdspxFlushDeferredFrees();
+		}
 		GodotGdspx.flushContactEvents();
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_fixed_update");
 		GodotGdspx.call1("gdspx_on_engine_fixed_update", "OnEngineFixedUpdate", delta, directHandler);
@@ -137,12 +170,18 @@ const GodotGdspx = {
 
 	godot_js_spx_on_engine_destroy__sig: 'v',
 	godot_js_spx_on_engine_destroy: function () {
+		if (typeof GdspxFlushDeferredFrees === 'function') {
+			GdspxFlushDeferredFrees();
+		}
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_destroy");
 		GodotGdspx.call0("gdspx_on_engine_destroy", "OnEngineDestroy", directHandler);
 	},
 
 	godot_js_spx_on_engine_reset__sig: 'v',
 	godot_js_spx_on_engine_reset: function () {
+		if (typeof GdspxFlushDeferredFrees === 'function') {
+			GdspxFlushDeferredFrees();
+		}
 		const directHandler = GodotGdspx.getDirectHandler("gdspx_on_engine_reset");
 		GodotGdspx.call0("gdspx_on_engine_reset", "OnEngineReset", directHandler);
 	},


### PR DESCRIPTION
## Summary
Optimize the Godot Web bridge for SPX batch sync by exposing raw buffer-oriented APIs and direct fast-path callbacks.

## What changed
- add raw batch-sync and input snapshot support in SPX managers
- switch sprite batch position retrieval to a raw buffer method with generated high-level bridge
- update `gdextension_spx_ext.cpp` and `godot_js_spx.cpp` to synthesize/forward the new raw paths
- refactor `gdspx.util.js` and `gdspx.js` to use fast-array transform helpers and shared ring buffers
- replace collision contact fallback string dispatch with direct callback entry points where available

## Why
The hot Web path should avoid extra array serialization, ad-hoc dispatch, and temporary allocations.
These changes make the JS <-> wasm bridge leaner and better aligned with SPX batch workloads.

## Testing
- validated together with SPX codegen output via `make generate-bindings`
- verified generated Web/native bridge code paths match the new raw APIs