### PR TITLE
fix: draw pen strokes immediately on move_to

### DIFF
--- a/modules/spx/spx_pen.cpp
+++ b/modules/spx/spx_pen.cpp
@@ -88,6 +88,23 @@ void SpxPen::_start_new_line() {
 	}
 }
 
+void SpxPen::_append_current_point_if_needed(GdVec2 position) {
+	current_pen_pos = position;
+	if (!is_pen_down || current_line == nullptr) {
+		return;
+	}
+
+	if (current_line->get_point_count() > 0) {
+		Vector2 last_point = current_line->get_point_position(current_line->get_point_count() - 1);
+		float distance = last_point.distance_to(current_pen_pos);
+		if (distance >= min_draw_distance) {
+			current_line->add_point(current_pen_pos);
+		}
+	} else {
+		current_line->add_point(current_pen_pos);
+	}
+}
+
 Color SpxPen::_get_current_color() const {
 	Color final_color = pen_properties.color;
 	// Apply saturation and brightness
@@ -102,19 +119,7 @@ Color SpxPen::_get_current_color() const {
 
 void SpxPen::on_update(float delta) {
 	if (move_by_mouse) {
-		current_pen_pos = Input::get_singleton()->get_mouse_position();
-	}
-
-	if (is_pen_down && current_line) {
-		if (current_line->get_point_count() > 0) {
-			Vector2 last_point = current_line->get_point_position(current_line->get_point_count() - 1);
-			float distance = last_point.distance_to(current_pen_pos);
-			if (distance >= min_draw_distance) {
-				current_line->add_point(current_pen_pos);
-			}
-		} else {
-			current_line->add_point(current_pen_pos);
-		}
+		_append_current_point_if_needed(Input::get_singleton()->get_mouse_position());
 	}
 }
 
@@ -175,7 +180,7 @@ void SpxPen::stamp() {
 }
 
 void SpxPen::move_to(GdVec2 position) {
-	current_pen_pos = position;
+	_append_current_point_if_needed(position);
 }
 
 void SpxPen::on_down(GdBool p_move_by_mouse) {

--- a/modules/spx/spx_pen.h
+++ b/modules/spx/spx_pen.h
@@ -65,6 +65,7 @@ private:
 	void _destroy_pen_root();
 	Line2D *_create_new_line();
 	void _start_new_line();
+	void _append_current_point_if_needed(GdVec2 position);
 	Color _get_current_color() const;
 	void _stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation_radians, GdVec2 scale);
 	Ref<Texture2D> _resolve_stamp_texture(const String &texture_path);


### PR DESCRIPTION
## Summary

This fixes pen strokes that were not rendered immediately for regular `move_to` updates.

Previously, pen points were only appended during `on_update()`. That worked for mouse-driven pen movement, but it delayed regular scripted pen movement until the next frame. In cases like issue (https://github.com/goplus/sb2xbp/issues/335), the script could clear the pen again before the pending point was ever rendered, making the stroke appear missing.

## Changes

- add `_append_current_point_if_needed(GdVec2 position)` to centralize pen point appending
- update `current_pen_pos` inside that helper
- call the helper directly from `move_to()` so non-mouse pen movement renders immediately
- keep `on_update()` responsible only for `move_by_mouse` pen updates

## Verification

- `make build-desktop`
- `go test . -run 'TestPenComponent(Stamp|Pen|Default|Ignores)'`
- repro demo: `go run ./cmd/spxrunner .tmp/84713608`
- confirmed the progress-bar pen stroke now appears correctly