### PR TITLE
fix: use rendered pixels for point hit testing

### DIFF
--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -505,6 +505,17 @@ GdBool SpxSpriteMgr::check_collision(GdObj obj, GdObj target, GdBool is_src_trig
 GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger) {
 	SPX_REQUIRE_SPRITE_RETURN(false)
 	point.y = -point.y;
+
+	if (!sprite->is_visible_in_tree()) {
+		return false;
+	}
+
+	PixelCollisionQuery query;
+	if (build_pixel_collision_query(sprite.get(), query, true, true) && ensure_query_image(query)) {
+		Color color;
+		return read_query_pixel(query, point, color) && color.a > 0.0f;
+	}
+
 	return sprite->check_collision_with_point(point, is_trigger);
 }
 


### PR DESCRIPTION
## Summary
- switch sprite point hit testing to rendered-pixel sampling before falling back to shape collision
- ignore invisible sprites during point hit detection
- preserve click-through behavior for fully ghosted pixels by requiring sampled alpha > 0

## Background
Scratch click picking follows the rendered silhouette instead of the coarse collision shape. This change aligns Godot point hit testing with that behavior so semi-transparent rendered areas still participate, while fully transparent pixels do not.