### PR TITLE
fix: preserve pen-down state after erase_all

### DIFF
--- a/modules/spx/spx_pen.cpp
+++ b/modules/spx/spx_pen.cpp
@@ -136,6 +136,8 @@ void SpxPen::erase_all() {
 		return;
 	}
 
+	const bool was_pen_down = is_pen_down;
+
 	TypedArray<Node> children = pen_root->get_children();
 	for (int i = 0; i < children.size(); i++) {
 		Node *child = Object::cast_to<Node>(children[i]);
@@ -147,7 +149,10 @@ void SpxPen::erase_all() {
 		}
 	}
 	current_line = _create_new_line();
-	is_pen_down = false;
+	is_pen_down = was_pen_down;
+	if (is_pen_down && current_line != nullptr) {
+		current_line->add_point(current_pen_pos);
+	}
 }
 
 void SpxPen::_stamp_texture(const Ref<Texture2D> &texture, GdVec2 position, GdFloat rotation_radians, GdVec2 scale) {


### PR DESCRIPTION
## Title

fix: preserve pen-down state after erase_all

## Summary

`erase_all()` was clearing all drawn content but also resetting the internal pen state to `pen up`.
This caused a state mismatch after the immediate-draw fix in `dce526af`:
the runtime still expected the pen to keep drawing, but the Godot pen implementation had already stopped.

As a result, the first segment after `eraseAll` could be skipped, which showed up as a missing head/body joint in projects such as `509531007`.

## Changes

- Preserve the previous `is_pen_down` state inside `SpxPen::erase_all()`
- Recreate the current line after clearing
- If the pen was already down, re-seed the new line with `current_pen_pos`

## Why

This keeps `eraseAll` scoped to clearing rendered strokes only, without unexpectedly changing whether the pen is currently drawing.

That matches the expected behavior for scripts that continue issuing drawing moves immediately after a clear.

## Verification

- Reproduced against the `spx4.4.1` line after `dce526af`
- Rebuilt:
  - `gdspxrt2.2.3`
  - `gdspx2.2.3`
- Verified the fix targets the remaining missing joint case where the head connection was not drawn
