### PR TITLE
fix: align point hit testing with Scratch semantics

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -635,8 +635,8 @@ static void gdextension_spx_sprite_check_collision(GdObj obj, GdObj target, GdBo
 	*ret_val = spriteMgr->check_collision(obj, target, is_src_trigger, is_dst_trigger);
 }
 
-static void gdextension_spx_sprite_check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger, GdBool *ret_val) {
-	*ret_val = spriteMgr->check_collision_with_point(obj, point, is_trigger);
+static void gdextension_spx_sprite_check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_click_query, GdBool *ret_val) {
+	*ret_val = spriteMgr->check_collision_with_point(obj, point, is_click_query);
 }
 
 static void gdextension_spx_sprite_set_debug_collision_visible(GdObj obj, GdBool visible) {

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -372,7 +372,7 @@ typedef void (*GDExtensionSpxSpriteGetChildRotation)(GdObj obj, GdString path, G
 typedef void (*GDExtensionSpxSpriteSetChildScale)(GdObj obj, GdString path, GdVec2 scale);
 typedef void (*GDExtensionSpxSpriteGetChildScale)(GdObj obj, GdString path, GdVec2 *ret_value);
 typedef void (*GDExtensionSpxSpriteCheckCollision)(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger, GdBool *ret_value);
-typedef void (*GDExtensionSpxSpriteCheckCollisionWithPoint)(GdObj obj, GdVec2 point, GdBool is_trigger, GdBool *ret_value);
+typedef void (*GDExtensionSpxSpriteCheckCollisionWithPoint)(GdObj obj, GdVec2 point, GdBool is_click_query, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteSetDebugCollisionVisible)(GdObj obj, GdBool visible);
 typedef void (*GDExtensionSpxSpriteIsDebugCollisionVisible)(GdObj obj, GdBool *ret_value);
 typedef void (*GDExtensionSpxSpriteCreateBackdrop)(GdString path, GdObj *ret_value);

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -502,19 +502,21 @@ GdBool SpxSpriteMgr::check_collision(GdObj obj, GdObj target, GdBool is_src_trig
 	return sprite->check_collision(sprite_target.get(), is_src_trigger, is_dst_trigger);
 }
 
-GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger) {
+GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_click_query) {
 	SPX_REQUIRE_SPRITE_RETURN(false)
 	point.y = -point.y;
 
 	PixelCollisionQuery query;
-	// Scratch splits sensing from clicking here:
-	// - touching mouse ignores visible/ghost and uses the sprite's silhouette
-	// - clicking still respects ghost alpha for point hit testing
-	const bool is_sensing_query = !is_trigger;
-	const bool apply_collision_alpha = !is_sensing_query;
-	if (build_pixel_collision_query(sprite.get(), query, false, apply_collision_alpha) && ensure_query_image(query)) {
+	// Scratch keeps point sensing and click picking distinct:
+	// - click queries respect visibility and ghost alpha
+	// - sensing queries ignore both and use the sprite silhouette directly
+	if (build_pixel_collision_query(sprite.get(), query, is_click_query, is_click_query) && ensure_query_image(query)) {
 		Color color;
 		return read_query_pixel(query, point, color) && color.a > 0.0f;
+	}
+
+	if (is_click_query && !sprite->is_visible_in_tree()) {
+		return false;
 	}
 
 	// Keep point-query fallbacks aligned with the trigger footprint used by SPX's

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -506,17 +506,20 @@ GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool 
 	SPX_REQUIRE_SPRITE_RETURN(false)
 	point.y = -point.y;
 
-	if (!sprite->is_visible_in_tree()) {
-		return false;
-	}
-
 	PixelCollisionQuery query;
-	if (build_pixel_collision_query(sprite.get(), query, true, true) && ensure_query_image(query)) {
+	// Scratch splits sensing from clicking here:
+	// - touching mouse ignores visible/ghost and uses the sprite's silhouette
+	// - clicking still respects ghost alpha for point hit testing
+	const bool is_sensing_query = !is_trigger;
+	const bool apply_collision_alpha = !is_sensing_query;
+	if (build_pixel_collision_query(sprite.get(), query, false, apply_collision_alpha) && ensure_query_image(query)) {
 		Color color;
 		return read_query_pixel(query, point, color) && color.a > 0.0f;
 	}
 
-	return sprite->check_collision_with_point(point, is_trigger);
+	// Keep point-query fallbacks aligned with the trigger footprint used by SPX's
+	// mouse/tap detection, even when the pixel path is unavailable.
+	return sprite->check_collision_with_point(point, true);
 }
 
 void SpxSpriteMgr::set_debug_collision_visible(GdObj obj, GdBool visible) {

--- a/modules/spx/spx_sprite_mgr.cpp
+++ b/modules/spx/spx_sprite_mgr.cpp
@@ -506,6 +506,10 @@ GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool 
 	SPX_REQUIRE_SPRITE_RETURN(false)
 	point.y = -point.y;
 
+	if (is_click_query && !sprite->is_visible_in_tree()) {
+		return false;
+	}
+
 	PixelCollisionQuery query;
 	// Scratch keeps point sensing and click picking distinct:
 	// - click queries respect visibility and ghost alpha
@@ -513,10 +517,6 @@ GdBool SpxSpriteMgr::check_collision_with_point(GdObj obj, GdVec2 point, GdBool 
 	if (build_pixel_collision_query(sprite.get(), query, is_click_query, is_click_query) && ensure_query_image(query)) {
 		Color color;
 		return read_query_pixel(query, point, color) && color.a > 0.0f;
-	}
-
-	if (is_click_query && !sprite->is_visible_in_tree()) {
-		return false;
 	}
 
 	// Keep point-query fallbacks aligned with the trigger footprint used by SPX's

--- a/modules/spx/spx_sprite_mgr.h
+++ b/modules/spx/spx_sprite_mgr.h
@@ -156,7 +156,7 @@ public:
 	SPX_API GdVec2 get_child_scale(GdObj obj, GdString path);
 
 	SPX_API GdBool check_collision(GdObj obj, GdObj target, GdBool is_src_trigger, GdBool is_dst_trigger);
-	SPX_API GdBool check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_trigger);
+	SPX_API GdBool check_collision_with_point(GdObj obj, GdVec2 point, GdBool is_click_query);
 	SPX_API void set_debug_collision_visible(GdObj obj, GdBool visible);
 	SPX_API GdBool is_debug_collision_visible(GdObj obj);
 	SPX_API GdObj create_backdrop(GdString path);

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -656,8 +656,8 @@ void gdspx_sprite_check_collision(GdObj *obj, GdObj *target, GdBool *is_src_trig
 	*ret_val = spriteMgr->check_collision(*obj, *target, *is_src_trigger, *is_dst_trigger);
 }
 EMSCRIPTEN_KEEPALIVE
-void gdspx_sprite_check_collision_with_point(GdObj *obj, GdVec2 *point, GdBool *is_trigger, GdBool *ret_val) {
-	*ret_val = spriteMgr->check_collision_with_point(*obj, *point, *is_trigger);
+void gdspx_sprite_check_collision_with_point(GdObj *obj, GdVec2 *point, GdBool *is_click_query, GdBool *ret_val) {
+	*ret_val = spriteMgr->check_collision_with_point(*obj, *point, *is_click_query);
 }
 EMSCRIPTEN_KEEPALIVE
 void gdspx_sprite_set_debug_collision_visible(GdObj *obj, GdBool *visible) {

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -1464,12 +1464,12 @@ gdspx_sprite_check_collision(obj_low,obj_high,target_low,target_high,is_src_trig
 	FreeGdBool(_retValue); 
 	return _finalRetValue
 }
-gdspx_sprite_check_collision_with_point(obj_low,obj_high,point,is_trigger) {
+gdspx_sprite_check_collision_with_point(obj_low,obj_high,point,is_click_query) {
 	var _gdFuncPtr = Module._gdspx_sprite_check_collision_with_point; 
 	var _retValue = AllocGdBool();
 	var _arg0 = Module._gdspx_new_obj(obj_high, obj_low);
 	var _arg1 = ToGdVec2(point);
-	var _arg2 = ToGdBool(is_trigger);
+	var _arg2 = ToGdBool(is_click_query);
 	_gdFuncPtr(_arg0, _arg1, _arg2, _retValue);
 	FreeGdObj(_arg0); 
 	FreeGdVec2(_arg1); 


### PR DESCRIPTION
## Summary

Align point hit testing with Scratch's distinction between mouse sensing and click picking.

In Scratch, `touching [mouse-pointer]?` should ignore sprite visibility and ghost effect, while click picking should still respect ghost alpha so fully ghosted front sprites remain click-through.

This change updates `check_collision_with_point` so:
- sensing queries use the sprite silhouette even when hidden or ghosted
- click hit testing still respects ghost alpha
- fallback point collision continues to use the trigger footprint used by SPX mouse/tap detection

## Why

We hit two conflicting demos:

- Hidden sprites used as mouse probes should still detect `touching(mouse)`
- Fully ghosted front sprites should not block clicks on sprites underneath

Treating all point queries the same breaks one side or the other. This patch splits the semantics at the engine point-query layer.

## Changes

- interpret point queries as two modes:
- sensing mode ignores `visible` and ghost alpha
- click mode keeps ghost-alpha-aware hit testing
- keep fallback shape hit testing aligned with SPX trigger-based mouse/tap behavior

## Validation

- verified against Scratch renderer/vm behavior and comments
- paired with SPX-side change which routes `touching(mouse)` into the sensing query path

## Notes

This PR should be merged before the SPX PR that starts using the sensing query branch.