### PR TITLE
fix(spx): support KeyAny in input manager

### DIFF
--- a/modules/spx/spx_input_mgr.cpp
+++ b/modules/spx/spx_input_mgr.cpp
@@ -70,6 +70,9 @@ GdBool SpxInputMgr::get_mouse_state(GdInt mouse_id) {
 }
 GdBool SpxInputMgr::get_key(GdInt key) {
 	Input *input = Input::get_singleton();
+	if (key == KEY_ANY) {
+		return input->is_anything_pressed_except_mouse();
+	}
 	return input->is_key_pressed((Key)key) ||
 			input->is_key_label_pressed((Key)key);
 }

--- a/modules/spx/spx_input_mgr.h
+++ b/modules/spx/spx_input_mgr.h
@@ -67,6 +67,7 @@ public:
 	SPX_API void write_snapshot(float *out, int len);
 
 private:
+	static constexpr GdInt KEY_ANY = -1;
 	const StringName *get_registered_action(GdInt action_id) const;
 };
 


### PR DESCRIPTION
## Summary
Add native `KeyAny` support to the SPX input manager so `get_key(-1)` is handled at the Godot module layer.

## What changed
- define `KEY_ANY = -1` in `SpxInputMgr`
- make `SpxInputMgr::get_key()` return `Input::is_anything_pressed_except_mouse()` for `KEY_ANY`
- keep existing key and key-label checks unchanged for normal key codes

## Why
Some SPX projects use `keyPressed(KeyAny)` together with a separate mouse check. Before this change, `-1` was passed through to the normal key query path, so “any key” input was not detected correctly. Handling it in the native input manager keeps the behavior centralized and avoids runtime-side special casing.

## Testing
- verified SPX Go-side tests still pass with `go test ./...` in `spx-release`
- did not run a full Godot module rebuild in this change
