### PR TITLE
fix(svg): resolve fallback fonts by glyph availability

### DIFF
--- a/thirdparty/lunasvg/include/plutovg.h
+++ b/thirdparty/lunasvg/include/plutovg.h
@@ -850,6 +850,15 @@ PLUTOVG_API void plutovg_font_face_get_metrics(const plutovg_font_face_t* face, 
 PLUTOVG_API void plutovg_font_face_get_glyph_metrics(plutovg_font_face_t* face, float size, plutovg_codepoint_t codepoint, float* advance_width, float* left_side_bearing, plutovg_rect_t* extents);
 
 /**
+ * @brief Returns whether a font face contains a glyph for the specified codepoint.
+ *
+ * @param face A pointer to a `plutovg_font_face_t` object.
+ * @param codepoint The Unicode code point of the glyph.
+ * @return `true` when the font face resolves a non-zero glyph index for `codepoint`.
+ */
+PLUTOVG_API bool plutovg_font_face_has_glyph(plutovg_font_face_t* face, plutovg_codepoint_t codepoint);
+
+/**
  * @brief Retrieves embedded SVG glyph data for a specified codepoint when available.
  *
  * @param face A pointer to a `plutovg_font_face_t` object.

--- a/thirdparty/lunasvg/source/plutovg-font.c
+++ b/thirdparty/lunasvg/source/plutovg-font.c
@@ -297,6 +297,14 @@ void plutovg_font_face_get_glyph_metrics(plutovg_font_face_t* face, float size, 
     }
 }
 
+bool plutovg_font_face_has_glyph(plutovg_font_face_t* face, plutovg_codepoint_t codepoint)
+{
+    if(face == NULL)
+        return false;
+    glyph_t* glyph = plutovg_font_face_get_glyph(face, codepoint);
+    return glyph != NULL && glyph->index != 0;
+}
+
 int plutovg_font_face_get_glyph_svg(plutovg_font_face_t* face, plutovg_codepoint_t codepoint, const char** svg)
 {
     if(svg)

--- a/thirdparty/lunasvg/source/svgtextelement.cpp
+++ b/thirdparty/lunasvg/source/svgtextelement.cpp
@@ -12,13 +12,11 @@ namespace lunasvg {
 namespace {
 
 constexpr std::string_view kSPXDefaultFontFamily = "SPX Default";
-constexpr std::string_view kSPXSymbolsFontFamily = "Symbols";
 constexpr std::string_view kSPXEmojiFontFamily = "Emoji";
 
 enum class TextRunKind : uint8_t {
     Base,
     DefaultFallback,
-    SymbolsFallback,
     Emoji
 };
 
@@ -139,7 +137,7 @@ static bool isDefaultEmojiPresentationCodepoint(uint32_t codepoint)
         codepoint == 0x2B55;
 }
 
-static bool isSymbolsFallbackCodepoint(uint32_t codepoint)
+static bool isSymbolCodepoint(uint32_t codepoint)
 {
     return (codepoint >= 0x2190 && codepoint <= 0x21FF) ||
         (codepoint >= 0x2300 && codepoint <= 0x23FF) ||
@@ -147,7 +145,7 @@ static bool isSymbolsFallbackCodepoint(uint32_t codepoint)
         (codepoint >= 0x2900 && codepoint <= 0x2BFF);
 }
 
-static bool isDefaultFallbackCodepoint(uint32_t codepoint)
+static bool isDefaultTextFallbackCodepoint(uint32_t codepoint)
 {
     if(codepoint < 0x80 || isEmojiCandidateCodepoint(codepoint))
         return false;
@@ -171,18 +169,37 @@ static bool isDefaultFallbackCodepoint(uint32_t codepoint)
         (codepoint >= 0x20000 && codepoint <= 0x323AF);
 }
 
+static FontFace lookupFallbackFace(std::string_view family)
+{
+    return fontFaceCache()->getFontFace(family, false, false);
+}
+
+static bool fontFaceHasGlyph(const FontFace& face, uint32_t codepoint)
+{
+    return !face.isNull() && plutovg_font_face_has_glyph(face.get(), codepoint);
+}
+
 static TextRunKind classifyTextRunKind(uint32_t codepoint, TextRunKind previous, bool emojiPresentation)
 {
-    if(emojiPresentation || isDefaultEmojiPresentationCodepoint(codepoint))
-        return TextRunKind::Emoji;
-    if(isSymbolsFallbackCodepoint(codepoint))
-        return TextRunKind::SymbolsFallback;
-    if(isEmojiCandidateCodepoint(codepoint))
-        return TextRunKind::Emoji;
-    if(isDefaultFallbackCodepoint(codepoint))
-        return TextRunKind::DefaultFallback;
     if(isWhitespaceCodepoint(codepoint))
         return previous;
+
+    auto defaultFace = lookupFallbackFace(kSPXDefaultFontFamily);
+    auto emojiFace = lookupFallbackFace(kSPXEmojiFontFamily);
+    auto prefersEmoji = emojiPresentation || isDefaultEmojiPresentationCodepoint(codepoint) || isEmojiCandidateCodepoint(codepoint);
+    if(prefersEmoji) {
+        if(fontFaceHasGlyph(emojiFace, codepoint))
+            return TextRunKind::Emoji;
+        if(fontFaceHasGlyph(defaultFace, codepoint))
+            return TextRunKind::DefaultFallback;
+    }
+    if(isSymbolCodepoint(codepoint) || isDefaultTextFallbackCodepoint(codepoint)) {
+        if(fontFaceHasGlyph(defaultFace, codepoint))
+            return TextRunKind::DefaultFallback;
+        if(fontFaceHasGlyph(emojiFace, codepoint))
+            return TextRunKind::Emoji;
+    }
+
     return TextRunKind::Base;
 }
 
@@ -191,10 +208,8 @@ static Font resolveFragmentFont(const SVGTextPositioningElement* element, TextRu
     if(kind == TextRunKind::Base)
         return element->font();
 
-    const auto family = kind == TextRunKind::Emoji
-        ? kSPXEmojiFontFamily
-        : kind == TextRunKind::SymbolsFallback ? kSPXSymbolsFontFamily : kSPXDefaultFontFamily;
-    auto face = fontFaceCache()->getFontFace(family, false, false);
+    const auto family = kind == TextRunKind::Emoji ? kSPXEmojiFontFamily : kSPXDefaultFontFamily;
+    auto face = lookupFallbackFace(family);
     if(face.isNull())
         return element->font();
     return Font(face, element->font().size());


### PR DESCRIPTION
## Summary

- add a `plutovg_font_face_has_glyph()` helper so SVG text fallback can check glyph availability directly
- update SVG text run classification to choose between `Emoji` and `SPX Default` based on actual glyph presence
- remove the hard dependency on a separate `Symbols` fallback family
- preserve color emoji rendering while allowing non-emoji symbols to fall back to the default font when appropriate

## Why

The template-side font trimming removes the packaged symbols font, so the SVG fallback path needs to become glyph-aware instead of relying on a dedicated `Symbols` family.

## Behavior

- emoji candidates with glyphs in the bundled emoji font still render through the color emoji path
- symbol and fallback characters now prefer the default fallback font when it has coverage
- missing emoji candidates can safely fall back to the default font instead of requiring a separate symbols font

## Testing

- static code validation only
- full Godot rebuild was not run in this workspace