### PR TITLE
fix(spx): resize pen canvas with stage

### DIFF
--- a/modules/spx/gdextension_spx_ext.cpp
+++ b/modules/spx/gdextension_spx_ext.cpp
@@ -299,6 +299,10 @@ static void gdextension_spx_pen_destroy_all_pens() {
 	penMgr->destroy_all_pens();
 }
 
+static void gdextension_spx_pen_set_canvas_size(GdInt width, GdInt height) {
+	penMgr->set_canvas_size(width, height);
+}
+
 static void gdextension_spx_pen_create_pen(GdObj *ret_val) {
 	*ret_val = penMgr->create_pen();
 }
@@ -1477,6 +1481,7 @@ void gdextension_spx_setup_interface() {
 	REGISTER_SPX_INTERFACE_FUNC(spx_navigation_set_obstacle);
 	REGISTER_SPX_INTERFACE_FUNC(spx_navigation_find_path);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_destroy_all_pens);
+	REGISTER_SPX_INTERFACE_FUNC(spx_pen_set_canvas_size);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_create_pen);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_destroy_pen);
 	REGISTER_SPX_INTERFACE_FUNC(spx_pen_batch_update_commands);

--- a/modules/spx/gdextension_spx_ext.h
+++ b/modules/spx/gdextension_spx_ext.h
@@ -283,6 +283,7 @@ typedef void (*GDExtensionSpxNavigationSetObstacle)(GdObj obj, GdBool enabled);
 typedef void (*GDExtensionSpxNavigationFindPath)(GdVec2 p_from, GdVec2 p_to, GdBool with_jump, GdArray *ret_value);
 // SpxPen
 typedef void (*GDExtensionSpxPenDestroyAllPens)();
+typedef void (*GDExtensionSpxPenSetCanvasSize)(GdInt width, GdInt height);
 typedef void (*GDExtensionSpxPenCreatePen)(GdObj *ret_value);
 typedef void (*GDExtensionSpxPenDestroyPen)(GdObj obj);
 typedef void (*GDExtensionSpxPenBatchUpdateCommands)(const float *buffer_data, int len);

--- a/modules/spx/spx_pen_mgr.cpp
+++ b/modules/spx/spx_pen_mgr.cpp
@@ -203,6 +203,12 @@ void SpxPenMgr::destroy_all_pens() {
 	}
 }
 
+void SpxPenMgr::set_canvas_size(GdInt width, GdInt height) {
+	if (surface != nullptr) {
+		surface->set_canvas_size(Size2i(width, height));
+	}
+}
+
 void SpxPenMgr::flush_all() {
 	if (surface != nullptr) {
 		surface->flush();

--- a/modules/spx/spx_pen_mgr.h
+++ b/modules/spx/spx_pen_mgr.h
@@ -51,6 +51,7 @@ public:
 	void on_reset(int reset_code) override;
 
 	SPX_API void destroy_all_pens();
+	SPX_API void set_canvas_size(GdInt width, GdInt height);
 	void flush_all();
 	SPX_API GdObj create_pen();
 	SPX_API void destroy_pen(GdObj obj);

--- a/modules/spx/spx_pen_surface.cpp
+++ b/modules/spx/spx_pen_surface.cpp
@@ -217,6 +217,22 @@ void SpxPenSurface::initialize(const Size2i &p_size) {
 	add_child(canvas_sprite);
 }
 
+void SpxPenSurface::set_canvas_size(const Size2i &p_size) {
+	ERR_FAIL_NULL(render_target);
+	ERR_FAIL_NULL(canvas);
+
+	const Size2i next_size(MAX(1, p_size.x), MAX(1, p_size.y));
+	if (canvas_size == next_size) {
+		return;
+	}
+
+	canvas->discard_pending();
+	canvas_size = next_size;
+	render_target->set_size(canvas_size);
+	clear_requested = true;
+	dirty = true;
+}
+
 void SpxPenSurface::draw_line(const Vector2 &p_from, const Vector2 &p_to, float p_width, const Color &p_color, bool p_draw_start_cap) {
 	ERR_FAIL_NULL(canvas);
 	const Vector2 canvas_origin = Vector2(canvas_size) * 0.5f;

--- a/modules/spx/spx_pen_surface.h
+++ b/modules/spx/spx_pen_surface.h
@@ -88,6 +88,7 @@ protected:
 
 public:
 	void initialize(const Size2i &p_size);
+	void set_canvas_size(const Size2i &p_size);
 	void draw_line(const Vector2 &p_from, const Vector2 &p_to, float p_width, const Color &p_color, bool p_draw_start_cap);
 	void draw_stamp(const Ref<Texture2D> &p_texture, const Vector2 &p_position, float p_rotation, const Vector2 &p_scale);
 	void clear();

--- a/platform/web/godot_js_spx.cpp
+++ b/platform/web/godot_js_spx.cpp
@@ -320,6 +320,10 @@ void gdspx_pen_destroy_all_pens() {
 	 penMgr->destroy_all_pens();
 }
 EMSCRIPTEN_KEEPALIVE
+void gdspx_pen_set_canvas_size(GdInt *width, GdInt *height) {
+	 penMgr->set_canvas_size(*width, *height);
+}
+EMSCRIPTEN_KEEPALIVE
 void gdspx_pen_create_pen(GdObj *ret_val) {
 	*ret_val = penMgr->create_pen();
 }

--- a/platform/web/js/engine/gdspx.js
+++ b/platform/web/js/engine/gdspx.js
@@ -612,6 +612,16 @@ gdspx_pen_destroy_all_pens() {
 	_gdFuncPtr();
 
 }
+gdspx_pen_set_canvas_size(width_low,width_high,height_low,height_high) {
+	var _gdFuncPtr = Module._gdspx_pen_set_canvas_size;
+
+	var _arg0 = Module._gdspx_new_int(width_high, width_low);
+	var _arg1 = Module._gdspx_new_int(height_high, height_low);
+	_gdFuncPtr(_arg0, _arg1);
+	FreeGdInt(_arg0);
+	FreeGdInt(_arg1);
+
+}
 gdspx_pen_create_pen() {
 	var _gdFuncPtr = Module._gdspx_pen_create_pen;
 	var _retValue = AllocGdObj();


### PR DESCRIPTION
## Summary

- Add logical stage canvas resizing to `SpxPenSurface`.
- Clear pending pen draw commands and reset the render target when the canvas size changes.
- Expose `set_canvas_size` through the native GDExtension and Web bridges.

## Motivation

The pen surface was initialized from the viewport size, so stamps could be clipped when the logical SPX world size differed from the window size.

## Validation

- Host editor build passed.
- Web normal build passed.

## Dependency

This API is consumed by the corresponding SPX runtime change:
`fix/pen-stage-canvas-size`.
